### PR TITLE
Add test helper methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,7 @@ dependencies {
     implementation localGroovy()
     implementation gradleApi()
 
-    // TODO: Use version range for some of these?
-    implementation 'com.wooga.gradle:gradle-commons:0.1.0'
+    implementation 'com.wooga.gradle:gradle-commons:0.2.0'
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.github.stefanbirkner:system-rules:1.18.0'
     implementation 'junit:junit:4.13'

--- a/src/main/groovy/com/wooga/gradle/test/ConventionSource.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/ConventionSource.groovy
@@ -1,0 +1,40 @@
+package com.wooga.gradle.test
+
+class ConventionSource {
+    private interface ConventionSourceWriter {
+        String writeConventionSourceSet(String value)
+    }
+
+    private static class ExtensionConventSource implements ConventionSourceWriter {
+        private final String extensionName
+        private final String property
+
+        @Override
+        String writeConventionSourceSet(String value) {
+            "${extensionName}.${property} = ${value}"
+        }
+
+        ExtensionConventSource(String extensionName, String property) {
+            this.extensionName = extensionName
+            this.property = property
+        }
+    }
+
+    private final ConventionSourceWriter impl
+
+    private ConventionSource(ConventionSourceWriter impl) {
+        this.impl = impl
+    }
+
+    static ConventionSource extension(String extensionName, String property) {
+        new ConventionSource(new ExtensionConventSource(extensionName, property))
+    }
+
+    String write(String value) {
+        impl.writeConventionSourceSet(value)
+    }
+
+    String write(File file, String value) {
+        file << """${write(value)}"""
+    }
+}

--- a/src/main/groovy/com/wooga/gradle/test/PropertyQueryTaskWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/PropertyQueryTaskWriter.groovy
@@ -25,7 +25,7 @@ abstract class BasePropertyQueryTaskWriter {
     BasePropertyQueryTaskWriter(String path, String invocation = ".getOrNull()", String taskName = null) {
         this.path = path
         this.invocation = invocation
-        this.taskName = taskName ?: PropertyUtils.envNameFromProperty("query_${path}")
+        this.taskName = taskName ?: PropertyUtils.toCamelCase("query_${path}")
     }
 }
 

--- a/src/main/groovy/com/wooga/gradle/test/PropertyUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/PropertyUtils.groovy
@@ -1,6 +1,6 @@
 package com.wooga.gradle.test
 
-trait PropertyUtilsImpl {
+class PropertyUtils {
 
     /**
      * @param extensionName The name of the extension the property belongs to
@@ -14,8 +14,38 @@ trait PropertyUtilsImpl {
     static String envNameFromProperty(String property) {
         property.replaceAll(/([A-Z.])/, '_$1').replaceAll(/[.]/, '').toUpperCase()
     }
-}
 
-class PropertyUtils implements PropertyUtilsImpl {
+    static String toCamelCase(String input) {
+        input.replaceAll(/\(\)/,"").replaceAll(/((\/|-|_|\.)+)([\w])/, { all, delimiterAll, delimiter, firstAfter -> "${firstAfter.toUpperCase()}" })
+    }
+
+    /**
+     * Returns the {@code Provider} set method string for the given property name.
+     * This method simply appends {@code .set} to the provided property string.
+     *
+     * @param propertyName The property name to convert to a {@code Provider} set method
+     * @return The {@code Provider} set method string for the given property name.
+     */
+    static String toProviderSet(String propertyName) {
+        "${propertyName}.set"
+    }
+
+    /**
+     * Returns the setter method string for the given property name.
+     * <p>
+     * If the property name is fully qualified it will split at `.`
+     * and append the setter prefix to the last item.
+     * <p>
+     * {@code foo.bar.baz -> foo.bar.setBaz}
+     * @param propertyName The property name to convert to a setter
+     * @return The setter method string for the given property name.
+     */
+    static String toSetter(String propertyName) {
+        def propertyChain = propertyName.split(/\./).reverse().toList()
+        if (propertyChain.size() > 1) {
+            return (propertyChain.tail().reverse() << toSetter(propertyChain.head())).join(".")
+        }
+        "set${propertyChain.head().capitalize()}"
+    }
 }
 

--- a/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
@@ -1,0 +1,108 @@
+package com.wooga.gradle.test
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class IntegrationSpecSpec extends Specification {
+
+    @Subject
+    IntegrationSpec subjectUnderTest = new IntegrationSpec()
+
+
+    @Unroll
+    def "wrapValueBasedOnType wraps given value #rawValue of type #rawType to requested type #type"() {
+        expect:
+
+        String[] values = ["foo", "bar"] as String[]
+        subjectUnderTest.wrapValueBasedOnType(rawValue, type) == exptectedValue
+
+        where:
+        rawValue                                                   | rawType         | type                                  | exptectedValue
+        "some value"                                               | "String"        | "String"                              | "'${rawValue}'"
+        22                                                         | "Integer"       | "String"                              | "'${rawValue}'"
+        false                                                      | "Boolean"       | "String"                              | "'${rawValue}'"
+
+        ["some", "strings"]                                        | "List<String>"  | "String[]"                            | "['some', 'strings'] as String[]"
+        [22, 10, 23]                                               | "List<Integer>" | "String[]"                            | "['22', '10', '23'] as String[]"
+        [false, true, false]                                       | "List<Boolean>" | "String[]"                            | "['false', 'true', 'false'] as String[]"
+
+        [22, 10, 23]                                               | "List<Integer>" | "int[]"                               | "[22, 10, 23] as int[]"
+        [false, true, false]                                       | "List<Boolean>" | "boolean[]"                           | "[false, true, false] as boolean[]"
+
+        ["some", "strings"]                                        | "List<String>"  | "String..."                           | "'some', 'strings'"
+        [22, 10, 23]                                               | "List<Integer>" | "String..."                           | "'22', '10', '23'"
+        [false, true, false]                                       | "List<Boolean>" | "String..."                           | "'false', 'true', 'false'"
+
+        [22, 10, 23]                                               | "List<Integer>" | "int..."                              | "22, 10, 23"
+        [false, true, false]                                       | "List<Boolean>" | "boolean..."                          | "false, true, false"
+
+        ["some", "strings"]                                        | "List<String>"  | "List"                                | "['some', 'strings']"
+        [22, 10, 23]                                               | "List<Integer>" | "List"                                | "['22', '10', '23']"
+        [false, true, false]                                       | "List<Boolean>" | "List"                                | "['false', 'true', 'false']"
+
+        ["some", "strings"]                                        | "List<String>"  | "List<String>"                        | "['some', 'strings']"
+        [22, 10, 23]                                               | "List<Integer>" | "List<Integer>"                       | "[22, 10, 23]"
+        [false, true, false]                                       | "List<Boolean>" | "List<Boolean>"                       | "[false, true, false]"
+
+        ["foo": "bar", "true": false, "one": 1]                    | "Map"           | "Map"                                 | "['foo' : 'bar', 'true' : false, 'one' : 1]"
+        ["foo": "bar", "true": false, "one": 1]                    | "Map"           | "Map<String, String>"                 | "['foo' : 'bar', 'true' : 'false', 'one' : '1']"
+
+        "some value"                                               | "String"        | "Closure"                             | "{'${rawValue}'}"
+        22                                                         | "Integer"       | "Closure"                             | "{${rawValue}}"
+        false                                                      | "Boolean"       | "Closure"                             | "{${rawValue}}"
+
+        "some value"                                               | "String"        | "Closure<Object>"                     | "{new Object() {@Override String toString() { '${rawValue}' }}}"
+        22                                                         | "Integer"       | "Closure<String>"                     | "{'${rawValue}'}"
+        false                                                      | "Boolean"       | "Closure<String>"                     | "{'${rawValue}'}"
+
+        ["some", "strings"]                                        | "String"        | "Closure<List<String>>"               | "{['some', 'strings']}"
+        ["some", "strings"]                                        | "String"        | "Closure"                             | "{['some', 'strings']}"
+
+        "some value"                                               | "String"        | "Callable"                            | "new java.util.concurrent.Callable<java.lang.String>() {@Override java.lang.String call() throws Exception {'${rawValue}'}"
+        22                                                         | "Integer"       | "Callable"                            | "new java.util.concurrent.Callable<java.lang.Integer>() {@Override java.lang.Integer call() throws Exception {${rawValue}}"
+        false                                                      | "Boolean"       | "Callable"                            | "new java.util.concurrent.Callable<java.lang.Boolean>() {@Override java.lang.Boolean call() throws Exception {${rawValue}}"
+
+        "some value"                                               | "String"        | "Callable<Object>"                    | "new java.util.concurrent.Callable<Object>() {@Override Object call() throws Exception {new Object() {@Override String toString() { '${rawValue}' }}}"
+        22                                                         | "Integer"       | "Callable<String>"                    | "new java.util.concurrent.Callable<String>() {@Override String call() throws Exception {'${rawValue}'}"
+        false                                                      | "Boolean"       | "Callable<String>"                    | "new java.util.concurrent.Callable<String>() {@Override String call() throws Exception {'${rawValue}'}"
+
+        ["some", "strings"]                                        | "String"        | "Callable<List<String>>"              | "new java.util.concurrent.Callable<List<String>>() {@Override List<String> call() throws Exception {['some', 'strings']}"
+        ["some", "strings"]                                        | "String"        | "Callable"                            | "new java.util.concurrent.Callable<java.util.ArrayList>() {@Override java.util.ArrayList call() throws Exception {['some', 'strings']}"
+
+        "/some/path/to/a/file"                                     | "String"        | "File"                                | "new File('${rawValue}')"
+        "/some/path/to/a/file"                                     | "String"        | "RegularFile"                         | "project.layout.projectDirectory.file('${rawValue}')"
+        "/some/path/to/a/file"                                     | "String"        | "Directory"                           | "project.layout.projectDirectory.dir('${rawValue}')"
+        "/some/path/to/a/file"                                     | "String"        | "Provider<File>"                      | "project.provider({new File('${rawValue}')})"
+        "/some/path/to/a/file"                                     | "String"        | "Provider<RegularFile>"               | "project.layout.buildDirectory.file('${rawValue}')"
+        "/some/path/to/a/file"                                     | "String"        | "Provider<Directory>"                 | "project.layout.buildDirectory.dir('${rawValue}')"
+        ["some", "strings"]                                        | "String"        | "Provider<List<String>>"              | "project.provider({['some', 'strings']})"
+        ["foo": "bar", "true": false, "one": 1]                    | "Map"           | "Provider<Map<String, String>>"       | "project.provider({['foo' : 'bar', 'true' : 'false', 'one' : '1']})"
+        ["foo": ["bar"], "true": [false, false], "one": [1, 2, 3]] | "Map"           | "Provider<Map<String, List<String>>>" | "project.provider({['foo' : ['bar'], 'true' : ['false', 'false'], 'one' : ['1', '2', '3']]})"
+    }
+
+    def "wrapValueBasedOnType can wrap custom types with fallback closure"() {
+        given: "a fallback closure"
+        def fallback = { Object rawValue, String type, Closure<String> fallback ->
+            def value
+            switch (type) {
+                case "CustomType":
+                    def m = rawValue as Map
+                    value = "'My custom type is a string with value ${m["value"]} and foo ${m["foo"]}'"
+                    break
+                default:
+                    value = rawValue.toString()
+                    break
+            }
+            value
+        }
+
+        expect:
+        subjectUnderTest.wrapValueBasedOnType(rawValue, type, fallback) == exptectedValue
+
+        where:
+        rawValue                                 | rawType | type                               | exptectedValue
+        ["foo": "bar", "value": 22]              | "Map"   | "Provider<CustomType>"             | "project.provider({'My custom type is a string with value ${rawValue["value"]} and foo ${rawValue["foo"]}'})"
+        ["content": ["foo": "bar", "value": 22]] | "Map"   | "Provider<Map<String,CustomType>>" | "project.provider({['content' : 'My custom type is a string with value ${rawValue["content"]["value"]} and foo ${rawValue["content"]["foo"]}']})"
+    }
+}

--- a/src/test/groovy/com/wooga/gradle/test/PropertyUtilsSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/PropertyUtilsSpec.groovy
@@ -1,7 +1,7 @@
-package com.wooga.gradle
+package com.wooga.gradle.test
 
-import com.wooga.gradle.test.PropertyUtils
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class PropertyUtilsSpec extends Specification {
 
@@ -28,4 +28,31 @@ class PropertyUtilsSpec extends Specification {
         propertyName | expectedEnvironmentName
         "kat.zen"    | "KAT_ZEN"
     }
+
+    @Unroll
+    def "toProviderSet returns a provider set method invocation #expectedResult from property #property"() {
+        expect:
+        PropertyUtils.toProviderSet(property) == expectedResult
+
+        where:
+        property      | expectedResult
+        "foo"         | "foo.set"
+        "foo.bar"     | "foo.bar.set"
+        "foo.bar.baz" | "foo.bar.baz.set"
+    }
+
+    @Unroll
+    def "toSetter returns a setter method invocation #expectedResult from property #property"() {
+        expect:
+        PropertyUtils.toSetter(property) == expectedResult
+
+        where:
+        property      | expectedResult
+        "foo"         | "setFoo"
+        "foo.bar"     | "foo.setBar"
+        "foo.bar.baz" | "foo.bar.setBaz"
+
+    }
+
+
 }


### PR DESCRIPTION
## Descriptions

This patch adds new additional test helper methods to make unit and integration testing easier.

### wrapValueBasedOnType

I refactored the whole method and added a better fallback solution. I managed to get rid of the `rawValueEscaped` usecases by using more recursive calls. The system also supports now multiple generic types and fully qualified types or static sub types
(e.g. `Foo<com.bar.Baz, String>`

The fallback closure supports now all three parameters andmakes it possible to call the fallback back from the fallback. This projects can declare a static closure with all custom sub types which needs to be wrapped.

### helper methods

We do a lot of property testing. The mentioned method `wrapValueBasedOnType` plays a big role here. The pattern always looks something like this:

```groovy
property   | method             | rawValue  | type
"property" | "property.set"     | "value_1" | "String"
"property" | "property.set"     | "value_2" | "Provider<String>"
"property" | "setProperty"      | "value_3" | "String"
"property" | "setProperty"      | "value_4" | "Provider<String>"
```

This adds some redundancy which makes it also harder to copy blocks for other property names. So this patch add new methods
* toProviderSet
* toSetter

to generate the provider set and setter method name from a property name.

```groovy
property   | method                  | rawValue  | type
"property" | toProviderSet(property) | "value_1" | "String"
"property" | toProviderSet(property) | "value_2" | "Provider<String>"
"property" | toSetter(property)      | "value_3" | "String"
"property" | toSetter(property)      | "value_4" | "Provider<String>"
```

I also added a `toCamelCase` method to create better test task names. At the moment these just use the environment name creation method which looks not very great in the build logs or build.gradle files.

I had to update the gradle-commons library to `0.2.0`

Changes
=======

* ![IMPROVE] `wrapValueBasedOnType` method refactor
* ![ADD] `toProviderSet` and `toSetter` convenient methods.
* ![IMPROVE] generated task names with `toCamelCase` helper method


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
