### PR TITLE
Add/gradle and executable utils

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/GradleSpecUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/GradleSpecUtils.groovy
@@ -1,0 +1,40 @@
+package com.wooga.gradle.test
+
+import groovy.json.StringEscapeUtils
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class GradleSpecUtils {
+
+
+
+    static String[] executedTasks(String gradleStdOut) {
+        //example line: "> Task :sonarScannerInstall SKIPPED"
+        def tasks = []
+        def taskBaseStart = "> Task "
+        gradleStdOut.readLines().each {
+            if(it.startsWith(taskBaseStart)) {
+                def taskName = it.replace(taskBaseStart, "").split(" ")[0].trim()
+                tasks.add(taskName)
+            }
+        }
+        return tasks
+    }
+
+    static String taskLog(String task, String stdOutput) {
+        if(!task.startsWith(":")) {
+            task = ":" + task
+        }
+        String taskString = "> Task ${task}"
+        int taskBeginIdx = stdOutput.indexOf(taskString) + taskString.length()
+        String taskTail = stdOutput.substring(taskBeginIdx)
+        int taskEndIdx = taskTail.indexOf("> Task")
+
+        def logs = taskEndIdx > 0? taskTail.substring(0, taskEndIdx) : taskTail
+        return taskString + logs
+    }
+
+
+}

--- a/src/main/groovy/com/wooga/gradle/test/GradleSpecUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/GradleSpecUtils.groovy
@@ -1,11 +1,6 @@
 package com.wooga.gradle.test
 
-import groovy.json.StringEscapeUtils
 
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.Paths
-import java.util.regex.Matcher
 import java.util.regex.Pattern
 
 class GradleSpecUtils {

--- a/src/main/groovy/com/wooga/gradle/test/SpecUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/SpecUtils.groovy
@@ -1,0 +1,53 @@
+package com.wooga.gradle.test
+
+import groovy.json.StringEscapeUtils
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class SpecUtils {
+
+    static File emptyTmpFile(String first, String... more) {
+        return emptyTmpFile(Paths.get(first, more))
+    }
+
+    static File emptyTmpFile(Path path) {
+        File file = path.toFile()
+        file.createNewFile()
+        file.deleteOnExit()
+        return file
+    }
+
+    static File emptyTmpFile() {
+        return Files.createTempFile("tmp", "").toFile()
+    }
+
+    static String escapedPath(String path) {
+        if (isWindows()) {
+            return StringEscapeUtils.escapeJava(path)
+        }
+        return path
+    }
+
+    static Throwable rootCause(Throwable e) {
+        if(e.cause == null || e.cause == e) {
+            return e
+        }
+        return rootCause(e.cause)
+    }
+
+    static boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("windows")
+    }
+
+    static boolean isUnix() {
+        return System.getProperty("os.name").toLowerCase().contains("linux") ||
+                System.getProperty("os.name").toLowerCase().contains("unix")
+    }
+
+    static boolean isMacOS() {
+        return System.getProperty("os.name").toLowerCase().contains("mac")
+    }
+
+}

--- a/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
@@ -4,7 +4,7 @@ import com.wooga.gradle.test.run.result.TaskResult
 import nebula.test.functional.ExecutionResult
 import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
 
-import static com.wooga.gradle.test.GradleSpecUtils.isWindows
+import static com.wooga.gradle.test.SpecUtils.isWindows
 
 class ArgsReflectorExecutable {
 
@@ -17,11 +17,11 @@ class ArgsReflectorExecutable {
         this.envTokens = envTokens
         this.argsTokens = argsTokens
         this.fileTokens = ["[[${fakeExec.name}]]", "[[end ${fakeExec.name}]]"]
-        this.executable = write(fakeExec, fileTokens, exitCode)
+        this.executable = write(fakeExec, fileTokens, envTokens, argsTokens, exitCode)
 
     }
 
-    private static File write(File executable, String[] fileTokens, int exitCode) {
+    private static File write(File executable, String[] fileTokens, String[] envTokens, String[] argsTokens, int exitCode) {
         if (isWindows()) {
             executable << """
                 @echo off
@@ -29,6 +29,7 @@ class ArgsReflectorExecutable {
                 echo ${argsTokens[0]}
                 echo %*
                 echo ${argsTokens[1]}
+
                 echo ${envTokens[0]}
                 set
                 echo ${envTokens[1]}
@@ -38,13 +39,15 @@ class ArgsReflectorExecutable {
         } else {
             executable << """
                 #!/usr/bin/env bash
-                echo [[${executable.name}]]
-                echo [[arguments]]
+                echo ${fileTokens[0]}
+                echo ${argsTokens[0]}
                 echo \$@
-                echo [[environment]]
+                echo ${argsTokens[1]}
+
+                echo ${envTokens[0]}
                 env
-                echo [[end]]
-                echo [[end ${executable.name}]]
+                echo ${envTokens[1]}
+                echo ${fileTokens[1]}
                 exit ${exitCode}
             """.stripIndent()
         }
@@ -59,7 +62,7 @@ class ArgsReflectorExecutable {
         return allResults(result.standardOutput)
     }
 
-    Result firsResult(TaskResult taskResult) {
+    Result firstResult(TaskResult taskResult) {
         return firstResult(taskResult.taskLog)
     }
 

--- a/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
@@ -6,11 +6,40 @@ import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
 
 import static com.wooga.gradle.test.SpecUtils.isWindows
 
+/**
+ Represents a script executable that "reflects" (prints) all its arguments and current environment at execution time.
+ Some ussage examples below:
+
+ <br><br>
+ Creates a `ArgsReflectorExecutable` object:
+ <pre>{@code def reflectorExec = FakeExecutables.argsReflector("filePath", exitStatus)}</pre>
+ <br>
+ Executable file that should be used to run this object somewhere
+ <pre>{@code reflectorExec.executable}</pre>
+ <br>
+
+ First execution result of this file in a given log:
+ <pre>{@code ArgsReflectorExecutable.Result result = reflectorExec.firstResult(log)}</pre>
+ <br>
+
+ You can also fetch all results inside a given log like this:
+ <pre>{@code List<ArgsReflectorExecutable.Result>   results = reflectorExec.allResults(log)}</pre>
+ <br>
+
+ With an ArgsReflectorExecutable.Result object, you can get:
+ <pre>{@code
+ result.args //List<String> of arguments passed to this executable
+ result.envs //Map<Sring, String> representing the environment at the executable execution}</pre>
+
+ */
 class ArgsReflectorExecutable {
 
     final String[] argsTokens
     final String[] envTokens
     final String[] fileTokens
+    /**
+     * executable file that should be used to run this object somewhere
+     */
     final File executable
 
     ArgsReflectorExecutable(File fakeExec, String[] argsTokens, String[] envTokens, int exitCode) {
@@ -53,36 +82,54 @@ class ArgsReflectorExecutable {
         }
     }
 
-
+    /**
+     * @param result nebula integration test exectuion result object
+     * @return first execution result from the given gradle execution, null if none was found
+     */
     Result firstResult(ExecutionResult result) {
         return firstResult(result.standardOutput)
     }
-
+    /**
+     * @param result nebula integration test exectuion result object
+     * @return all execution results from the given gradle execution
+     */
     Result[] allResults(ExecutionResult result) {
         return allResults(result.standardOutput)
     }
-
+    /**
+     * @param taskResult TaskResult object representing a gradle task execution
+     * @return first execution result from given task, null if none was found
+     */
     Result firstResult(TaskResult taskResult) {
         return firstResult(taskResult.taskLog)
     }
-
+    /**
+     * @param taskResult TaskResult object representing a gradle task execution
+     * @return all execution results from given task
+     */
     Result[] allResults(TaskResult taskResult) {
         return allResults(taskResult.taskLog)
     }
-
+    /**
+     * @param stdOutput log string that contains the result of a reflector executable execution
+     * @return first execution result within given log, null if none was found
+     */
     Result firstResult(String stdOutput) {
         def currentIndex = stdOutput.indexOf(fileTokens[0])
-        if(currentIndex > -1) {
+        if (currentIndex > -1) {
             return new Result(stdOutput)
         }
         return null
     }
-
+    /**
+     * @param stdOutput log string that contains the result of a reflector executable execution
+     * @return all execution results within given log
+     */
     Result[] allResults(String stdOutput) {
         def results = new ArrayList<Result>()
         def log = stdOutput
         def currentIndex = log.indexOf(fileTokens[0])
-        while(currentIndex > -1) {
+        while (currentIndex > -1) {
             def currentLog = log.substring(currentIndex)
             results.add(new Result(currentLog))
             currentIndex = currentLog.substring(currentIndex + fileTokens[0].length()).
@@ -93,11 +140,17 @@ class ArgsReflectorExecutable {
 
 
     class Result {
+        /**
+         * list of arguments passed to a reflector executable
+         */
         final ArrayList<String> args;
+        /**
+         * environment at reflector executable execution
+         */
         final Map<String, String> envs;
 
-        Result(String stdOutput) {
-            def fileLog = substringBetween(stdOutput, fileTokens[0], fileTokens[1])
+        Result(String reflectorStdOut) {
+            def fileLog = substringBetween(reflectorStdOut, fileTokens[0], fileTokens[1])
             this.args = loadArgs(fileLog, argsTokens[0], argsTokens[1])
             this.envs = loadEnvs(fileLog, envTokens[0], envTokens[1])
         }
@@ -105,14 +158,14 @@ class ArgsReflectorExecutable {
         private static ArrayList<String> loadArgs(String stdOutput,
                                                   String argumentStartToken, String argumentEndToken) {
             def lastExecutionOffset = stdOutput.lastIndexOf(argumentStartToken)
-            if(lastExecutionOffset < 0) {
+            if (lastExecutionOffset < 0) {
                 System.out.println(stdOutput)
                 throw new IllegalArgumentException("stdout couldn't match given arguments token ${argumentStartToken}")
             }
             def lastExecTailString = stdOutput.substring(lastExecutionOffset)
             def argsString = substringBetween(lastExecTailString, argumentStartToken, argumentEndToken)
             def parts = argsString.split(" ").
-                    findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }
+                    findAll { !StringUtils.isEmpty(it) }.collect { it.trim() }
             return parts
         }
 
@@ -120,7 +173,7 @@ class ArgsReflectorExecutable {
                                                     String environmentStartToken, String environmentEndToken) {
             def argsString = substringBetween(stdOutput, environmentStartToken, environmentEndToken)
             def parts = argsString.split(System.lineSeparator()).
-                    findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }
+                    findAll { !StringUtils.isEmpty(it) }.collect { it.trim() }
             return parts.collectEntries {
                 return it.split("=", 2)
             }

--- a/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
@@ -1,0 +1,134 @@
+package com.wooga.gradle.test.executable
+
+import com.wooga.gradle.test.run.result.TaskResult
+import nebula.test.functional.ExecutionResult
+import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
+
+import static com.wooga.gradle.test.GradleSpecUtils.isWindows
+
+class ArgsReflectorExecutable {
+
+    final String[] argsTokens
+    final String[] envTokens
+    final String[] fileTokens
+    final File executable
+
+    ArgsReflectorExecutable(File fakeExec, String[] argsTokens, String[] envTokens, int exitCode) {
+        this.envTokens = envTokens
+        this.argsTokens = argsTokens
+        this.fileTokens = ["[[${fakeExec.name}]]", "[[end ${fakeExec.name}]]"]
+        this.executable = write(fakeExec, fileTokens, exitCode)
+
+    }
+
+    private static File write(File executable, String[] fileTokens, int exitCode) {
+        if (isWindows()) {
+            executable << """
+                @echo off
+                echo ${fileTokens[0]}
+                echo ${argsTokens[0]}
+                echo %*
+                echo ${argsTokens[1]}
+                echo ${envTokens[0]}
+                set
+                echo ${envTokens[1]}
+                echo ${fileTokens[1]}
+                exit ${exitCode}
+            """.stripIndent()
+        } else {
+            executable << """
+                #!/usr/bin/env bash
+                echo [[${executable.name}]]
+                echo [[arguments]]
+                echo \$@
+                echo [[environment]]
+                env
+                echo [[end]]
+                echo [[end ${executable.name}]]
+                exit ${exitCode}
+            """.stripIndent()
+        }
+    }
+
+
+    Result firstResult(ExecutionResult result) {
+        return firstResult(result.standardOutput)
+    }
+
+    Result[] allResults(ExecutionResult result) {
+        return allResults(result.standardOutput)
+    }
+
+    Result firsResult(TaskResult taskResult) {
+        return firstResult(taskResult.taskLog)
+    }
+
+    Result[] allResults(TaskResult taskResult) {
+        return allResults(taskResult.taskLog)
+    }
+
+    Result firstResult(String stdOutput) {
+        def currentIndex = stdOutput.indexOf(fileTokens[0])
+        if(currentIndex > -1) {
+            return new Result(stdOutput)
+        }
+        return null
+    }
+
+    Result[] allResults(String stdOutput) {
+        def results = new ArrayList<Result>()
+        def log = stdOutput
+        def currentIndex = log.indexOf(fileTokens[0])
+        while(currentIndex > -1) {
+            def currentLog = log.substring(currentIndex)
+            results.add(new Result(currentLog))
+            currentIndex = currentLog.substring(currentIndex + fileTokens[0].length()).
+                    indexOf(fileTokens[0])
+        }
+        return results
+    }
+
+
+    class Result {
+        final ArrayList<String> args;
+        final Map<String, String> envs;
+
+        Result(String stdOutput) {
+            def fileLog = substringBetween(stdOutput, fileTokens[0], fileTokens[1])
+            this.args = loadArgs(fileLog, argsTokens[0], argsTokens[1])
+            this.envs = loadEnvs(fileLog, envTokens[0], envTokens[1])
+        }
+
+        private static ArrayList<String> loadArgs(String stdOutput,
+                                                  String argumentStartToken, String argumentEndToken) {
+            def lastExecutionOffset = stdOutput.lastIndexOf(argumentStartToken)
+            if(lastExecutionOffset < 0) {
+                System.out.println(stdOutput)
+                throw new IllegalArgumentException("stdout couldn't match given arguments token ${argumentStartToken}")
+            }
+            def lastExecTailString = stdOutput.substring(lastExecutionOffset)
+            def argsString = substringBetween(lastExecTailString, argumentStartToken, argumentEndToken)
+            def parts = argsString.split(" ").
+                    findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }
+            return parts
+        }
+
+        private static Map<String, String> loadEnvs(String stdOutput,
+                                                    String environmentStartToken, String environmentEndToken) {
+            def argsString = substringBetween(stdOutput, environmentStartToken, environmentEndToken)
+            def parts = argsString.split(System.lineSeparator()).
+                    findAll {!StringUtils.isEmpty(it) }.collect{ it.trim() }
+            return parts.collectEntries {
+                return it.split("=", 2)
+            }
+        }
+
+        private static String substringBetween(String base, String from, String to) {
+            def customArgsIndex = base.indexOf(from)
+            def tailString = base.substring(customArgsIndex)
+            def endIndex = tailString.indexOf(to)
+            return tailString.substring(from.length(), endIndex)
+        }
+    }
+
+}

--- a/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
@@ -2,6 +2,24 @@ package com.wooga.gradle.test.executable
 
 import static com.wooga.gradle.test.SpecUtils.isWindows
 
+/**
+ * This static class contains several methods for creating useful scripts to fake executable files.
+ *
+ //this creates a `ArgsReflectorExecutable` object
+ def reflectorExec = FakeExecutables.argsReflector("filePath", exitStatus)
+
+ //executable file that should be used to run this object somewhere
+ reflectorExec.executable
+
+ //returns the first execution result of this file in a given log
+ ArgsReflectorExecutable.Result result = reflectorExec.firstResult(log)
+ //you can also fetch all results inside a given log like this
+ List< ArgsReflectorExecutable.Result> results = reflectorExec.allResults(log)
+
+ //with an ArgsReflectorExecutable.Result object, you can get:
+ result.args //List<String> of arguments passed to this executable
+ result.envs //Map<Sring, String> representing the environment at the executable execution
+ */
 class FakeExecutables {
 
     /**

--- a/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
@@ -1,10 +1,6 @@
 package com.wooga.gradle.test.executable
 
-
-import java.nio.file.Path
-import java.nio.file.Paths
-
-import static com.wooga.gradle.test.GradleSpecUtils.isWindows
+import static com.wooga.gradle.test.SpecUtils.isWindows
 
 class FakeExecutables {
 
@@ -18,7 +14,7 @@ class FakeExecutables {
         String osAwareFakePath = isWindows() && !fakeFilePath.endsWith(".bat")?
                 "${fakeFilePath}.bat" :
                 fakeFilePath
-        File fakeExec = setupExecutableFile(Paths.get(osAwareFakePath), overwrites)
+        File fakeExec = setupExecutableFile(new File(osAwareFakePath), overwrites)
         fakeExec.deleteOnExit()
         if (isWindows()) {
             //https://stackoverflow.com/questions/935609/batch-parameters-everything-after-1
@@ -56,7 +52,7 @@ class FakeExecutables {
         String osAwareFakePath = isWindows() && !fakeFilePath.endsWith(".bat")?
                 "${fakeFilePath}.bat" :
                 fakeFilePath
-        File fakeExec = setupExecutableFile(Paths.get(osAwareFakePath), overwrites)
+        File fakeExec = setupExecutableFile(new File(osAwareFakePath), overwrites)
         fakeExec.deleteOnExit()
 
         String[] argsTokens = ["[[arguments]]", "[[end arguments]]"]
@@ -64,13 +60,12 @@ class FakeExecutables {
         return new ArgsReflectorExecutable(fakeExec, argsTokens, envTokens, exitCode)
     }
 
-    private static File setupExecutableFile(Path fakeFilePath, boolean overwrites) {
-        File fakeExec = fakeFilePath.toFile()
+    private static File setupExecutableFile(File fakeExec, boolean overwrites) {
         if (fakeExec.exists()) {
             if (overwrites) {
                 fakeExec.delete()
             } else {
-                throw new IllegalArgumentException("File ${fakeFilePath} already exists")
+                throw new IllegalArgumentException("File ${fakeExec} already exists")
             }
         }
         fakeExec.createNewFile()

--- a/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/FakeExecutables.groovy
@@ -1,0 +1,80 @@
+package com.wooga.gradle.test.executable
+
+
+import java.nio.file.Path
+import java.nio.file.Paths
+
+import static com.wooga.gradle.test.GradleSpecUtils.isWindows
+
+class FakeExecutables {
+
+    /**
+     * Creates an executable script that calls its first argument, passing through the other arguments.
+     * @param fakeFilePath where the script should be created
+     * @param overwrites if it should overwrite any existing file
+     * @return executable file representing created script
+     */
+    static File runFirstParam(String fakeFilePath, boolean overwrites=true) {
+        String osAwareFakePath = isWindows() && !fakeFilePath.endsWith(".bat")?
+                "${fakeFilePath}.bat" :
+                fakeFilePath
+        File fakeExec = setupExecutableFile(Paths.get(osAwareFakePath), overwrites)
+        fakeExec.deleteOnExit()
+        if (isWindows()) {
+            //https://stackoverflow.com/questions/935609/batch-parameters-everything-after-1
+            fakeExec << """
+                @echo off
+                echo [[${fakeExec.name}]]
+                for /f "tokens=1,* delims= " %%a in ("%*") do set ALL_BUT_FIRST=%%b 
+                call %1 %ALL_BUT_FIRST%
+                echo [[end ${fakeExec.name}]]
+                exit %errorlevel%
+            """.stripIndent()
+        } else {
+            //running subscript with '.' in practice includes it on the mother script, including its parameters
+            fakeExec <<
+                    """#!/usr/bin/env bash
+                echo [[${fakeExec.name}]]
+                fst_param=\$1
+                shift
+                . "\${fst_param}"
+                echo [[end ${fakeExec.name}]]
+                exit \$?
+            """.stripIndent()
+        }
+    }
+
+
+    /**
+     * Creates an executable script that logs all of its arguments and its environment at execution time.
+     * @param  fakeFilePath where the script should be created
+     * @param exitCode which exit code should the script return
+     * @param overwrites if it should overwrite any existing file
+     * @return FakeExecutable object representing created script
+     */
+    static ArgsReflectorExecutable argsReflector(String fakeFilePath, int exitCode, boolean overwrites=true) {
+        String osAwareFakePath = isWindows() && !fakeFilePath.endsWith(".bat")?
+                "${fakeFilePath}.bat" :
+                fakeFilePath
+        File fakeExec = setupExecutableFile(Paths.get(osAwareFakePath), overwrites)
+        fakeExec.deleteOnExit()
+
+        String[] argsTokens = ["[[arguments]]", "[[end arguments]]"]
+        String[] envTokens = ["[[environment]]", "[[end environment]]"]
+        return new ArgsReflectorExecutable(fakeExec, argsTokens, envTokens, exitCode)
+    }
+
+    private static File setupExecutableFile(Path fakeFilePath, boolean overwrites) {
+        File fakeExec = fakeFilePath.toFile()
+        if (fakeExec.exists()) {
+            if (overwrites) {
+                fakeExec.delete()
+            } else {
+                throw new IllegalArgumentException("File ${fakeFilePath} already exists")
+            }
+        }
+        fakeExec.createNewFile()
+        fakeExec.executable = true
+        return fakeExec
+    }
+}

--- a/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
@@ -3,6 +3,8 @@ package com.wooga.gradle.test.run.result
 import com.wooga.gradle.test.GradleSpecUtils
 import nebula.test.functional.ExecutionResult
 
+import static com.wooga.gradle.test.GradleSpecUtils.normalizeTaskName
+
 class GradleRunResult {
 
     final String[] orderedTasks
@@ -16,18 +18,22 @@ class GradleRunResult {
         this.orderedTasks = GradleSpecUtils.executedTasks(stdOutput)
         this.tasks = Collections.unmodifiableMap(orderedTasks.collectEntries { taskName ->
             String taskLog = GradleSpecUtils.taskLog(taskName, stdOutput)
-            return [taskName: new TaskResult(taskName, taskLog, this)]
+            return [(normalizeTaskName(taskName)): new TaskResult(taskName, taskLog, this)]
         })
     }
 
     TaskResult getAt(String taskName) {
-        return this.tasks[taskName]
+        return this.tasks[normalizeTaskName(taskName)]
     }
 
     boolean compareExecutionOrder(String baseTaskName, String otherTaskName, Closure<Boolean> cmpOp) {
-        return cmpOp(orderedTasks.findIndexOf {it == baseTaskName},
-                        orderedTasks.findIndexOf {it == otherTaskName})
+        return cmpOp(orderedTasks.findIndexOf {
+                        normalizeTaskName(it) == normalizeTaskName(baseTaskName)},
+                     orderedTasks.findIndexOf {
+                        normalizeTaskName(it) == normalizeTaskName(otherTaskName)})
     }
+
+
 }
 
 

--- a/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
@@ -1,0 +1,34 @@
+package com.wooga.gradle.test.run.result
+
+import com.wooga.gradle.test.GradleSpecUtils
+import nebula.test.functional.ExecutionResult
+
+class GradleRunResult {
+
+    final String[] orderedTasks
+    final Map<String, TaskResult> tasks
+
+    GradleRunResult(ExecutionResult result) {
+        this(result.standardOutput)
+    }
+
+    GradleRunResult(String stdOutput) {
+        this.orderedTasks = GradleSpecUtils.executedTasks(stdOutput)
+        this.tasks = Collections.unmodifiableMap(orderedTasks.collectEntries { taskName ->
+            String taskLog = GradleSpecUtils.taskLog(taskName, stdOutput)
+            return [taskName: new TaskResult(taskName, taskLog, this)]
+        })
+    }
+
+    TaskResult getAt(String taskName) {
+        return this.tasks[taskName]
+    }
+
+    boolean compareExecutionOrder(String baseTaskName, String otherTaskName, Closure<Boolean> cmpOp) {
+        return cmpOp(orderedTasks.findIndexOf {it == baseTaskName},
+                        orderedTasks.findIndexOf {it == otherTaskName})
+    }
+}
+
+
+

--- a/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/GradleRunResult.groovy
@@ -5,6 +5,35 @@ import nebula.test.functional.ExecutionResult
 
 import static com.wooga.gradle.test.GradleSpecUtils.normalizeTaskName
 
+/**
+ * Represents the execution results of a gradle execution. Task names can be  either ':task' or just 'task'.
+ * Some usage examples below:
+ * <br><br>
+ * Creates a new gradle run from a gradle execution log
+ * <pre>
+ * {@code
+ String log = "..."
+ def result = new GradleRunResult(log)
+ }
+ * </pre>
+ *
+ * All tasks in execution order:
+ * <pre>{@code result.orderedTasks}</pre>
+ <br>
+ String with execution logs for a given task {@code "taskName"}:
+ * <pre>{@code result["taskName"].taskLog}</pre>
+ <br>
+
+ execution order comparision, all of those return booleans
+ <pre>
+  {@code
+ result["dep1"].wasExecutedBefore("dep2", ":taskName")
+ result["dep2"].wasExecutedBefore("taskName")
+ result[":dep2"].wasExecutedAfter("dep1")
+ result[":taskName"].wasExecutedAfter(":dep1", "dep2")
+ }
+ * </pre>
+ */
 class GradleRunResult {
 
     final String[] orderedTasks
@@ -22,10 +51,23 @@ class GradleRunResult {
         })
     }
 
+    /**
+     * gets the task results of a given task
+     * @param taskName name of the task to get results from.
+     * @return {@code TaskResult} object representing the gradle execution result for a single task,
+     * null if no such task exists in the current execution
+     */
     TaskResult getAt(String taskName) {
         return this.tasks[normalizeTaskName(taskName)]
     }
-
+    /**
+     * Compares the execution order of two tasks.
+     * @param baseTaskName Base task
+     * @param otherTaskName  task to be compared against base task
+     * @param cmpOp - Closure {@code (int, int -> boolean)} where the comparison operation is done.
+     * The int parameters are the task indexes of {@code baseTaskName} and {@code otherTaskName} respectively
+     * @return boolean result of cmpOp
+     */
     boolean compareExecutionOrder(String baseTaskName, String otherTaskName, Closure<Boolean> cmpOp) {
         return cmpOp(orderedTasks.findIndexOf {
                         normalizeTaskName(it) == normalizeTaskName(baseTaskName)},

--- a/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
@@ -1,0 +1,25 @@
+package com.wooga.gradle.test.run.result
+
+class TaskResult {
+    final String taskName
+    final String taskLog
+    final GradleRunResult runResult
+
+    TaskResult(String taskName, String taskLog, GradleRunResult runResult) {
+        this.taskName = taskName
+        this.taskLog = taskLog
+        this.runResult = runResult
+    }
+
+    boolean wasExecutedBefore(String otherTaskName) {
+        return runResult.compareExecutionOrder(taskName, otherTaskName) {
+            taskIndex, otherTaskIndex -> taskIndex < otherTaskIndex
+        }
+    }
+
+    boolean wasExecutedAfter(String otherTaskName) {
+        return runResult.compareExecutionOrder(taskName, otherTaskName) {
+            taskIndex, otherTaskIndex -> taskIndex > otherTaskIndex
+        }
+    }
+}

--- a/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
@@ -11,15 +11,19 @@ class TaskResult {
         this.runResult = runResult
     }
 
-    boolean wasExecutedBefore(String otherTaskName) {
-        return runResult.compareExecutionOrder(taskName, otherTaskName) {
-            taskIndex, otherTaskIndex -> taskIndex < otherTaskIndex
+    boolean wasExecutedBefore(String... otherTaskNames) {
+        return otherTaskNames.every {otherTaskName ->
+            return runResult.compareExecutionOrder(taskName, otherTaskName) {
+                taskIndex, otherTaskIndex -> taskIndex < otherTaskIndex
+            }
         }
     }
 
-    boolean wasExecutedAfter(String otherTaskName) {
-        return runResult.compareExecutionOrder(taskName, otherTaskName) {
-            taskIndex, otherTaskIndex -> taskIndex > otherTaskIndex
+    boolean wasExecutedAfter(String... otherTaskNames) {
+        return otherTaskNames.every {otherTaskName ->
+            return runResult.compareExecutionOrder(taskName, otherTaskName) {
+                taskIndex, otherTaskIndex -> taskIndex > otherTaskIndex
+            }
         }
     }
 }

--- a/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/run/result/TaskResult.groovy
@@ -1,5 +1,6 @@
 package com.wooga.gradle.test.run.result
 
+
 class TaskResult {
     final String taskName
     final String taskLog
@@ -10,7 +11,11 @@ class TaskResult {
         this.taskLog = taskLog
         this.runResult = runResult
     }
-
+    /**
+     * Checks if given tasks were executed before this one
+     * @param otherTaskNames task names of tasks to compare against this one
+     * @return true if all given tasks were executed before this, false otherwise
+     */
     boolean wasExecutedBefore(String... otherTaskNames) {
         return otherTaskNames.every {otherTaskName ->
             return runResult.compareExecutionOrder(taskName, otherTaskName) {
@@ -18,7 +23,11 @@ class TaskResult {
             }
         }
     }
-
+    /**
+     * Checks if given tasks were executed after this one
+     * @param otherTaskNames task names of tasks to compare against this one
+     * @return true if all given tasks were executed after this, false otherwise
+     */
     boolean wasExecutedAfter(String... otherTaskNames) {
         return otherTaskNames.every {otherTaskName ->
             return runResult.compareExecutionOrder(taskName, otherTaskName) {

--- a/src/test/groovy/com/wooga/gradle/test/executable/FakeExecutablesSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/executable/FakeExecutablesSpec.groovy
@@ -1,0 +1,167 @@
+package com.wooga.gradle.test.executable
+
+import spock.lang.Requires
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.util.concurrent.TimeUnit
+
+class FakeExecutablesSpec extends Specification {
+
+    @Requires({ os.windows })
+    @Unroll
+    def "creates executable which logs its own arguments and environment on windows"() {
+        given: "a file path"
+        and: "a expected exit status"
+
+        when: "creating and executing args reflector executable"
+        def reflectorExec = FakeExecutables.argsReflector(filePath, exitStatus)
+        String[] envs = environment.toArray(new String[0])
+        def (process, log) = runWindowsBatScript(reflectorExec.executable, arguments, envs)
+
+        then: "executable was executed"
+        log.size() > 0
+        log.contains("[[end ${filePath}.bat]]")
+        log.contains("[[${filePath}.bat]]")
+        and: "exit status is the expected one"
+        exitStatus == process.exitValue()
+        and: "used arguments are recorded on result"
+        def result = reflectorExec.firstResult(log)
+        result.args == arguments
+        and: "used environment are recorded on result"
+        result.envs.entrySet().containsAll(environment.collectEntries {
+            return it.split("=")
+        }.entrySet())
+
+        where:
+        filePath | exitStatus | arguments                   | environment
+        "script" | 0          | ["arg1=a", "arg2", "arg:3"] | ["a=b"]
+        "scrept" | 0          | ["arg", "--arg2"]           | ["a=b", "b=c"]
+        "scropt" | 1          | ["arg1=a", "arg2", "arg:3"] | []
+        "scrupt" | 1          | ["arg", "arg2-b"]           | ["c=d"]
+    }
+
+
+    @Requires({ !os.windows })
+    @Unroll
+    def "creates executable which logs its own arguments and environment on unix"() {
+        given: "a file path"
+        and: "a expected exit status"
+
+        when: "creating and executing args reflector executable"
+        def executable = FakeExecutables.argsReflector(filePath, exitStatus)
+        String[] envs = environment.toArray(new String[0])
+        def process = Runtime.getRuntime().
+                exec("sh ${executable.executable.absolutePath} ${arguments.join(" ")}".toString(), envs)
+        def log = stringFromStream(process.inputStream)
+        process.waitFor(1000, TimeUnit.MILLISECONDS)
+
+        then: "executable was executed"
+        log.size() > 0
+        log.contains("[[end ${filePath}]]")
+        log.contains("[[${filePath}]]")
+        and: "exit status is the expected one"
+        exitStatus == process.exitValue()
+        and: "used arguments are recorded on result"
+        def result = executable.firstResult(log)
+        result.args == arguments
+        and: "used environment are recorded on result"
+        result.envs.entrySet().containsAll(environment.collectEntries {
+            return it.split("=")
+        }.entrySet())
+
+        where:
+        filePath | exitStatus | arguments                   | environment
+        "script" | 0          | ["arg1=a", "arg2", "arg:3"] | ["a=b"]
+        "scrept" | 0          | ["arg", "--arg2"]           | ["a=b", "b=c"]
+        "scropt" | 1          | ["arg1=a", "arg2", "arg:3"] | []
+        "scrupt" | 1          | ["arg", "arg2-b"]           | ["c=d"]
+    }
+
+    @Requires({ os.windows })
+    @Unroll
+    def "creates custom reflector executable on windows"() {
+        given: "a executable script file"
+        File fakeExecutable = new File("${filePath}.bat")
+        fakeExecutable.executable = true
+        fakeExecutable.createNewFile()
+        fakeExecutable.deleteOnExit()
+        and: "some delimiter tokens"
+        String[] argsTokens = ["[[startargs]]", "[[endargs]]"]
+        String[] envTokens = ["[[startenv]]", "[[endenv]]"]
+        and: "some exit code"
+
+        when: "creating and executing args reflector executable"
+        def reflectorExec = new ArgsReflectorExecutable(fakeExecutable, argsTokens, envTokens, exitStatus)
+        String[] envs = environment.toArray(new String[0])
+        def (process, log) = runWindowsBatScript(reflectorExec.executable, arguments, envs)
+
+        then: "executable was executed"
+        log.size() > 0
+        log.contains("[[end ${filePath}.bat]]")
+        log.contains("[[${filePath}.bat]]")
+        argsTokens.every { log.contains(it) }
+        envTokens.every { log.contains(it) }
+        and: "exit status is the expected one"
+        exitStatus == process.exitValue()
+        and: "used arguments are recorded on result"
+        def result = reflectorExec.firstResult(log)
+        result.args == arguments
+        and: "used environment are recorded on result"
+        result.envs.entrySet().containsAll(environment.collectEntries {
+            return it.split("=")
+        }.entrySet())
+
+        where:
+        filePath      | exitStatus | arguments                   | environment
+        "path"        | 0          | ["arg1=a", "arg2", "arg:3"] | ["a=b"]
+        "other"       | 0          | ["arg", "--arg2"]           | ["a=b", "b=c"]
+        "screept"     | 1          | ["arg1=a", "arg2", "arg:3"] | []
+        "otherscript" | 1          | ["arg", "arg2-b"]           | ["c=d"]
+    }
+
+    @Requires({ os.windows })
+    @Unroll
+    def "creates script that runs executable passed as parameter"() {
+        given: "a executable script file"
+        def runFirstExec = FakeExecutables.runFirstParam(filePath)
+        and: "a executable to pass as parameter"
+        and: "parameters for this executable"
+        when:
+        def arguments = [fileToRun.executable.absolutePath] + toRunParams
+        def (process, log) = runWindowsBatScript(runFirstExec, arguments, null)
+
+        then: "run first param executable was executed"
+        log.size() > 0
+        log.contains("[[${filePath}.bat]]")
+        and: "parameter executable was executed with remaining params"
+        def result = fileToRun.firstResult(log)
+        result.args == toRunParams
+        process.exitValue() == expectedExitStatus
+        where:
+        filePath      | fileToRun                                           | toRunParams | expectedExitStatus
+        "script"      | FakeExecutables.argsReflector("reflector", 0)       | ["a", "b"]  | 0
+        "otherscript" | FakeExecutables.argsReflector("otherreflector", 10) | ["a", "b"]  | 10
+    }
+
+
+    String stringFromStream(InputStream inputStream) {
+        StringBuilder output = new StringBuilder();
+        BufferedReader reader = new BufferedReader(
+                new InputStreamReader(inputStream));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            output.append(line + System.lineSeparator());
+        }
+        return output.toString()
+    }
+
+    List<?> runWindowsBatScript(File script, List<String> arguments, String[] envs = null) {
+        def process = Runtime.getRuntime().
+                exec("cmd.exe /c \"${script.absolutePath} ${arguments.join(" ")}\"".toString(), envs)
+        def log = stringFromStream(process.inputStream)
+        process.waitFor(1000, TimeUnit.MILLISECONDS)
+        return [process, log]
+    }
+
+}

--- a/src/test/groovy/com/wooga/gradle/test/run/result/GradleRunResultSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/run/result/GradleRunResultSpec.groovy
@@ -1,0 +1,83 @@
+package com.wooga.gradle.test.run.result
+
+import spock.lang.Specification
+
+class GradleRunResultSpec extends Specification {
+
+    def "gradle tasks shown on log are listed in order"() {
+        given: "a gradle execution log with several tasks"
+        def dependency1 = "dep1"
+        def dependency2 = "dep2"
+        def taskName = "taskName"
+        def log = sampleLog(taskName, "", dependency1, dependency2)
+
+        when:
+        def result = new GradleRunResult(log)
+
+        then:
+        result.orderedTasks.toList() == [":dep1", ":dep2", ":taskName"]
+    }
+
+    def "can get log pertaining to a single gradle task execution"() {
+        given: "a gradle execution log"
+        def taskName = "taskName"
+        def taskLog = "Hi I'm a log"
+        def log = sampleLog(taskName, "Hi I'm a log")
+
+        when: "creating a new run result object with log of ran task"
+        def result = new GradleRunResult(log)
+
+        then: "it contains the ran task logs"
+        def expectedLog = """
+        > Task :${taskName}
+        ${taskLog}
+        :${taskName} (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.21 secs.
+        """.stripIndent().trim()
+        result[taskName].taskLog == expectedLog
+    }
+
+    def "can determine if one gradle task was ran before or after another"() {
+        given: "a gradle execution log with several tasks"
+        def dependency1 = "dep1"
+        def dependency2 = "dep2"
+        def taskName = "taskName"
+        def log = sampleLog(taskName, "", dependency1, dependency2)
+
+        when:
+        def result = new GradleRunResult(log)
+
+        then:
+        result["dep1"].wasExecutedBefore("dep2", ":taskName")
+        result["dep2"].wasExecutedBefore("taskName")
+        result[":dep2"].wasExecutedAfter("dep1")
+        result[":taskName"].wasExecutedAfter(":dep1", "dep2")
+    }
+
+
+    def sampleLog(String task, String taskLog, String... dependencies) {
+        return """
+        > Configure project :
+        All projects evaluated.
+        Selected primary task '${task}' from project :
+        Tasks to be executed: [${dependencies.collect{"task ':${it}'"}.join(", ")}]
+        Tasks that were excluded: []
+        ${
+            dependencies.collect {taskExecutionLog(it, "")}.join(System.lineSeparator())
+        }
+        ${taskExecutionLog(task, taskLog)}
+        BUILD SUCCESSFUL in 9s
+        1 actionable task: 1 executed
+        """.stripIndent()
+    }
+
+    def taskExecutionLog(String task, String log) {
+        return """
+        :${task} (Thread[Execution worker for ':' Thread 2,5,main]) started.
+        > Task :${task}
+        ${log}
+        :${task} (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.21 secs.
+        """.stripIndent()
+
+    }
+
+}


### PR DESCRIPTION
## Description
Added utilities for reading gradle test logs, and some commonly used fake executables.

`GradleRunResult` receives the the logs of a gradle execution, and is able to break it in per-task logs, show the order of execution of these tasks, as well as compare execution order.

With a log for a ran task `TaskName` and its dependencies `dep1` and `dep2`.
```groovy
String log = "..." //gradle execution log
def result = new GradleRunResult(log)

//returns all tasks in execution order
result.orderedTasks

//execution order comparision, all of those are booleans
result["dep1"].wasExecutedBefore("dep2", ":taskName")
result["dep2"].wasExecutedBefore("taskName")
//task name can be either ':task' or just 'task'
result[":dep2"].wasExecutedAfter("dep1")
result[":taskName"].wasExecutedAfter(":dep1", "dep2")

//returns a string with logs for the given task
result["taskName"].taskLog 
```

`FakeExecutables` is a static functions class which include two methods: `runFirstParam` and `argsReflector`. 

`runFirstParam` returns a script `File` which runs the first param given to it, that must be a executable path, passing the remainder parameters to this executable. This is useful to mock "wrappers" like `mono`, for instance.

`argsReflector` returns a script file wrapped inside a `ArgsReflectorExecutable` object, which returns the parameters that this file was ran on, was well as its environment at execution time.  This can be used to mock executables that are too heavy or too complex to be tested using the real files, as the Unity3D executable, for instance.

``` groovy
//this creates a `ArgsReflectorExecutable` object
 def reflectorExec = FakeExecutables.argsReflector("filePath", exitStatus)

//executable file that should be used to run this object somewhere
 reflectorExec.executable

//returns the first execution result of this file in a given log
 ArgsReflectorExecutable.Result result = reflectorExec.firstResult(log)
 //you can also fetch all results inside a given log like this
 List< ArgsReflectorExecutable.Result> results = reflectorExec.allResults(log) 
 
//with an ArgsReflectorExecutable.Result object, you can get:
 result.args //List<String> of arguments passed to this executable
 result.envs //Map<Sring, String> representing the environment at the executable execution
```

Some extra, general utility functions were also added under `SpecUtils` and `GradleSpecUtils`

## Changes
* ![ADD]  `SpecUtils` and `GradleSpecUtils` classes
* ![ADD]  `GradleRunResult` for operations on gradle logs
* ![ADD]  `FakeExecutables` for useful scripts to fake executables


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
