### PR TITLE
Upgrade to gradle-commons 1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation localGroovy()
     implementation gradleApi()
 
-    implementation 'com.wooga.gradle:gradle-commons:0.2.0'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.github.stefanbirkner:system-rules:1.18.0'
     implementation 'junit:junit:4.13'

--- a/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
@@ -57,13 +57,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
         wrapValueBasedOnType(rawValue, type.simpleName, fallback)
     }
 
-
-    // TODO:
-    static String toGradleDslString(Object value, String type) {
-
-    }
-
-    // TODO: TO be replaced by the above method
+    // TODO: To be deprecated in the future by a better implementation
     String wrapValueBasedOnType(Object rawValue, String type, Closure<String> fallback = null) {
         def value
         def subType = null


### PR DESCRIPTION
## Description

Upgrades to latest gradle-commons.

## Changes
* ![UPDATE] Upgrade to `gradle-commons` `1.0`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
