### PR TITLE
Refactor string type matching into a separate class

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
@@ -17,13 +17,17 @@
 
 package com.wooga.gradle.test
 
+import com.wooga.gradle.PlatformUtils
 import nebula.test.functional.ExecutionResult
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
+import java.nio.file.Files
+
 import static com.wooga.gradle.PlatformUtils.escapedPath
 import static com.wooga.gradle.PlatformUtils.windows
+
 
 class IntegrationSpec extends nebula.test.IntegrationSpec {
 
@@ -60,17 +64,10 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
     // TODO: To be deprecated in the future by a better implementation
     String wrapValueBasedOnType(Object rawValue, String type, Closure<String> fallback = null) {
         def value
-        def subType = null
 
-        if (type.endsWith("...") || type.endsWith("[]")) {
-            def parts = type.split(/(\.\.\.|\[\])/)
-            subType = parts.first()
-            type = type.endsWith("...") ? "..." : "[]"
-        } else {
-            def subtypeMatches = type =~ /(?<mainType>\w+)(<(?<subType>.*?)>)?/
-            subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
-            type = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
-        }
+        def match = StringTypeMatch.match(type)
+        type = match.mainType
+        def subType = match.subType
 
         switch (type) {
             case "Closure":

--- a/src/main/groovy/com/wooga/gradle/test/StringTypeMatch.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/StringTypeMatch.groovy
@@ -1,0 +1,20 @@
+package com.wooga.gradle.test
+
+class StringTypeMatch {
+    String mainType
+    String subType
+
+    static StringTypeMatch match(String type) {
+        StringTypeMatch result = new StringTypeMatch()
+        if (type.endsWith("...") || type.endsWith("[]")) {
+            def parts = type.split(/(\.\.\.|\[\])/)
+            result.subType = parts.first()
+            result.mainType = type.endsWith("...") ? "..." : "[]"
+        } else {
+            def subtypeMatches = type =~ /(?<mainType>\w+)(<(?<subType>.*?)>)?/
+            result.subType = (subtypeMatches.matches()) ? subtypeMatches.group("subType") : null
+            result.mainType = (subtypeMatches.matches()) ? subtypeMatches.group("mainType") : type
+        }
+        result
+    }
+}

--- a/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
@@ -1,5 +1,6 @@
 package com.wooga.gradle.test
 
+import org.junit.contrib.java.lang.system.EnvironmentVariables
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -8,6 +9,27 @@ class IntegrationSpecSpec extends Specification {
 
     @Subject
     IntegrationSpec subjectUnderTest = new IntegrationSpec()
+
+    @Unroll
+    def "matches types correctly"() {
+        when:
+        def matcher = StringTypeMatch.match(type)
+
+        then:
+        matcher.mainType == mainType
+        matcher.subType == subType
+
+        where:
+        type                     | mainType   | subType
+        "String"                 | "String"   | null
+        "String..."              | "..."      | "String"
+        "String[]"               | "[]"       | "String"
+        "List<String>"           | "List"     | "String"
+        "List<Boolean>"          | "List"     | "Boolean"
+        "Provider<Integer>"      | "Provider" | "Integer"
+        "List<List<Integer>>"    | "List"     | "List<Integer>"
+        "Provider<List<String>>" | "Provider" | "List<String>"
+    }
 
 
     @Unroll


### PR DESCRIPTION
## Description

Refactors the string type matching from the wrapValueBasedOnType function.

## Changes
* ![ADD] StringTypeMatch
* ![UPDATE] IntegrationSpec

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
