### PR TITLE
Add snyk monitoring [ATLAS-669]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@
  */
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_gradle_coveralls_token', variable: 'coveralls_token')]) {
-    buildJavaLibraryOSSRH()
+withCredentials([string(credentialsId: 'snyk-wdk-token', variable: 'SNYK_TOKEN')]) {
+  withEnv(['SNYK_ORG_NAME=wooga-pipeline', 'SNYK_AUTO_DOWNLOAD=YES']) {
+        buildJavaLibraryOSSRH()
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,10 @@ plugins {
     id 'signing'
     id 'nebula.release' version '15.2.0'
     id 'jacoco'
-    id 'com.github.kt3k.coveralls' version '2.8.2'
     id "io.github.gradle-nexus.publish-plugin" version "1.0.0"
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-wdk-java" version "0.3.0"
+    id "net.wooga.cve-dependency-resolution" version "0.3.0"
 }
 
 group 'com.wooga.gradle'
@@ -38,9 +40,9 @@ dependencies {
     implementation gradleApi()
 
     implementation 'com.wooga.gradle:gradle-commons:[1,2)'
-    implementation 'com.google.guava:guava:29.0-jre'
-    implementation 'com.github.stefanbirkner:system-rules:1.18.0'
-    implementation 'junit:junit:4.13'
+    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.github.stefanbirkner:system-rules:[1.18,2)'
+    implementation 'junit:junit:4.13.1'
 
     api 'com.netflix.nebula:nebula-test:[8,9)'
     api 'org.spockframework:spock-core:1.3-groovy-2.5'

--- a/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/IntegrationSpecSpec.groovy
@@ -1,6 +1,6 @@
 package com.wooga.gradle.test
 
-import org.junit.contrib.java.lang.system.EnvironmentVariables
+
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll


### PR DESCRIPTION
## Description

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin `net.wooga.cve-dependency-resolution` which applies overrides for dependencies with know fixes for security issues.

Along with the introduction of snyk I also upgraded/removed some depdencies. Coveralls produces a huge load of errors even with the latest version so I decided to remove it since we want/are moving to sonarqube (It is unknown at this time if this dependency is actually better or not).

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin
* ![REMOVE] coveralls plugin
* ![UPDATE] `com.google.guava:guava` to version `30.0-jre`
* ![UPDATE] `com.github.stefanbirkner:system-rules` to version `[1.18,2)`
* ![UPDATE] `junit:junit` to version `4.13.1`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"