### PR TITLE
Add support for setting null value/types, wildcards for property set invocations

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertySetInvocation.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertySetInvocation.groovy
@@ -10,6 +10,10 @@ abstract class PropertySetInvocation {
     abstract String getDefinition()
 
     /**
+     * No operation
+     */
+    static PropertySetInvocation none = new NonePropertySetInvocation()
+    /**
      * foobar.set(value)
      */
     static PropertySetInvocation providerSet = new ProviderPropertySetInvocation()
@@ -129,5 +133,21 @@ class CustomSetterPropertySetInvocation extends PropertySetInvocation {
 
     CustomSetterPropertySetInvocation(String setter) {
         setterName = setter
+    }
+}
+
+/**
+ * No operation
+ */
+class NonePropertySetInvocation extends PropertySetInvocation {
+
+    @Override
+    String getDefinition() {
+        "none"
+    }
+
+    @Override
+    String compose(String path, String wrappedValue) {
+        ""
     }
 }

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
@@ -10,6 +10,7 @@ import com.wooga.gradle.test.serializers.PropertyTypeSerializer
 import groovyjarjarcommonscli.MissingArgumentException
 import nebula.test.Integration
 import org.gradle.api.Action
+import org.spockframework.lang.Wildcard
 
 import java.util.function.Function
 
@@ -77,6 +78,13 @@ class PropertySetterWriter extends BasePropertyWriter {
     }
 
     /**
+     * Assigns no type
+     */
+    PropertySetterWriter set(Object value, Wildcard wildcard) {
+        set(value, Wildcard.class)
+    }
+
+    /**
      * Assigns the value and type of value to be set by the writer by its invocation
      */
     PropertySetterWriter set(TestValue value, Class type) {
@@ -129,6 +137,14 @@ class PropertySetterWriter extends BasePropertyWriter {
      */
     PropertySetterWriter use(PropertySetInvocation method) {
         this.setInvocation = method
+        this
+    }
+
+    /**
+     * Assigns the invocation to use when setting the property by script
+     */
+    PropertySetterWriter use(Wildcard) {
+        this.setInvocation = PropertySetInvocation.none
         this
     }
 
@@ -233,7 +249,7 @@ class PropertySetterWriter extends BasePropertyWriter {
 
     PropertyWrite write(IntegrationHandler integration) {
 
-        if (value == null) {
+        if (value == null && location != PropertyLocation.none) {
             throw new MissingArgumentException("No value was set. Please make sure to call the set(value, type) method")
         }
 

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
@@ -36,6 +36,9 @@ class PropertySetterWriterSpec extends MockTaskIntegrationSpec<PropertyTask> {
         "pancakeFlavor" | "mint"                              | String                  | PropertySetInvocation.providerSet | PropertyLocation.script
         "pancakeFlavor" | "chocolate"                         | String                  | PropertySetInvocation.providerSet | PropertyLocation.environment
         "pancakeFlavor" | "cow"                               | String                  | PropertySetInvocation.providerSet | PropertyLocation.property
+        "pancakeFlavor" | null                                | String                  | PropertySetInvocation.none        | PropertyLocation.none
+        "pancakeFlavor" | null                                | _                       | PropertySetInvocation.none        | PropertyLocation.none
+        "pancakeFlavor" | null                                | _                       | _                                 | PropertyLocation.none
         "bake"          | true                                | Boolean                 | PropertySetInvocation.providerSet | PropertyLocation.script
         "bake"          | true                                | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.script
         "bake"          | true                                | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.environment


### PR DESCRIPTION
## Description

Added support for setting null/wildcards for value/type/methods when wanting to use no property location (such as when checking the default value of a property without invoking any setter).

## Changes
* ![ADD] PropertySetterWriter : Missing support for setting null/wildcards f

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
