### PR TITLE
Add missing support for expecting project files, property location backwards compat

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/PropertyLocation.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/PropertyLocation.groovy
@@ -20,17 +20,36 @@ abstract class PropertyLocation {
     String toString() {
         return reason()
     }
+
     static PropertyLocation none = new NonePropertyLocation()
     static PropertyLocation script = new BuildScriptPropertyLocation()
     static PropertyLocation property = new PropertiesFilePropertyLocation()
     static PropertyLocation environment = new EnvironmentPropertyLocation()
     static PropertyLocation commandLine = new CommandLineOptionPropertyLocation()
+
+    static PropertyLocation valueOf(String name) {
+        switch (name) {
+            case "script":
+                return script
+            case "property":
+                return property
+            case "environment":
+                return environment
+            case "commandLine":
+                return commandLine
+        }
+        none
+    }
+
+    static PropertyLocation[] values() {
+        [none, script, property, environment, commandLine]
+    }
 }
 
 /**
  * Fallback which does nothing. NOTHING!
  */
-class NonePropertyLocation extends PropertyLocation{
+class NonePropertyLocation extends PropertyLocation {
 
     @Override
     String reason() {

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertyGetterTaskWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertyGetterTaskWriter.groovy
@@ -28,7 +28,7 @@ class PropertyGetterTaskWriter extends BasePropertyQueryTaskWriter {
     Function<String, String> onFilterStdout
 
     // By default, evaluate using script behavior
-    static PropertyEvaluation evaluation = new ScriptPropertyEvaluation()
+    PropertyEvaluation evaluation = new ScriptPropertyEvaluation()
 
     /**
      * Associates the type of property this query is checking.

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
@@ -117,6 +117,13 @@ class PropertySetterWriter extends BasePropertyWriter {
     /**
      * Assigns the location, which determines by what mechanism the value will be set (script, environment, etc)
      */
+    PropertySetterWriter to(Wildcard wildcard) {
+        to(PropertyLocation.none)
+    }
+
+    /**
+     * Assigns the location, which determines by what mechanism the value will be set (script, environment, etc)
+     */
     PropertySetterWriter toScript(PropertySetInvocation method = PropertySetInvocation.providerSet) {
         this.location = PropertyLocation.script
         this.setInvocation = method
@@ -149,6 +156,14 @@ class PropertySetterWriter extends BasePropertyWriter {
     }
 
     /**
+     * Instructs the writer to use the given key for the environment/property locations
+     */
+    PropertySetterWriter withKey(String key) {
+        withEnvironmentKey(key)
+        withPropertyKey(key)
+    }
+
+    /**
      * Instructs the writer to use a specific environment key to be used when setting the property onto the environment
      */
     PropertySetterWriter withEnvironmentKey(String key) {
@@ -165,12 +180,20 @@ class PropertySetterWriter extends BasePropertyWriter {
     }
 
     /**
-     * Instructs the writer to write to properties file and to the environment using the extension name
-     * instead of whatever was initially set
+     * Instructs the writer to write to properties file and to the environment using a key
+     * generated from the given object name (such as an extension) and the previously set property name.
      */
-    PropertySetterWriter forExtension(String extensionName) {
-        withPropertyKey(composePath(extensionName.toLowerCase(), propertyName))
-        withEnvironmentKey(envNameFromProperty(extensionName.toLowerCase(), propertyName))
+    PropertySetterWriter withKeyComposedFrom(String objectName) {
+        withPropertyKey(composePath(objectName.toLowerCase(), propertyName))
+        withEnvironmentKey(envNameFromProperty(objectName.toLowerCase(), propertyName))
+    }
+
+    /**
+     * Instructs the writer to write to properties file and to the environment using a key
+     * generated from the previously set object name and the previously set property name.
+     */
+    PropertySetterWriter withKeyComposed() {
+        withKeyComposedFrom(objectName)
     }
 
     /**

--- a/src/test/groovy/com/wooga/gradle/test/PropertyLocationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/PropertyLocationSpec.groovy
@@ -36,7 +36,37 @@ class PropertyLocationSpec extends Specification {
         PropertyLocation.script      | "b"
         PropertyLocation.property    | "c"
         PropertyLocation.environment | "d"
-
     }
+
+    def "can retrieve all values like an enum type"() {
+        when:
+        PropertyLocation[] locations = PropertyLocation.values()
+
+        then:
+        locations.length == 5
+        locations.contains(PropertyLocation.none)
+        locations.contains(PropertyLocation.script)
+        locations.contains(PropertyLocation.property)
+        locations.contains(PropertyLocation.environment)
+        locations.contains(PropertyLocation.commandLine)
+    }
+
+    @Unroll
+    def "can call valueOf for #name expecting #value like an enum type"() {
+        when:
+        def actual = PropertyLocation.valueOf(name)
+
+        then:
+        expected == actual
+
+        where:
+        name          | expected
+        "none"        | PropertyLocation.none
+        "script"      | PropertyLocation.script
+        "property"    | PropertyLocation.property
+        "environment" | PropertyLocation.environment
+        "commandLine" | PropertyLocation.commandLine
+    }
+
 }
 

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
@@ -1,7 +1,10 @@
 package com.wooga.gradle.test.writers
 
+import com.wooga.gradle.BaseSpec
 import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.test.mock.MockTask
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -11,7 +14,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
 
-class PropertyTask extends MockTask {
+class PropertyTask extends MockTask implements BaseSpec {
 
     static final String extensionName = "Foobar"
 
@@ -42,33 +45,40 @@ class PropertyTask extends MockTask {
     }
 
     private final ListProperty<String> tags
+
     ListProperty<String> getTags() {
         tags
     }
 
     private final Property<Integer> numbers
+
     @Input
     Property<Integer> getNumbers() {
         numbers
     }
+
     void setNumbers(Provider<Integer> value) {
         numbers.set(value)
     }
 
     private final Property<MockObject> custom
+
     @Input
     Property<MockObject> getCustom() {
         custom
     }
+
     void setCustom(Provider<MockObject> value) {
         custom.set(value)
     }
 
     private final Property<MockEnum> customEnum
+
     @Input
     Property<MockEnum> getCustomEnum() {
         customEnum
     }
+
     void setCustomEnum(Provider<MockEnum> value) {
         customEnum.set(value)
     }
@@ -112,6 +122,20 @@ class PropertyTask extends MockTask {
         })
     }
 
+    private final DirectoryProperty logsDir = objects.directoryProperty()
+
+    DirectoryProperty getLogsDir() {
+        logsDir
+    }
+
+    void setLogsDir(File value) {
+        logsDir.set(value)
+    }
+
+    void setLogsDir(Provider<Directory> value) {
+        logsDir.set(value)
+    }
+
     PropertyTask() {
         bake = project.objects.property(Boolean)
         logFile = project.objects.fileProperty()
@@ -122,7 +146,9 @@ class PropertyTask extends MockTask {
         customEnum = project.objects.property(MockEnum)
         exclude = project.objects.listProperty(File)
 
+        numbers.convention(PropertyTaskConventions.numbers.getIntegerValueProvider(project))
         bake.convention(PropertyTaskConventions.bake.getBooleanValueProvider(project))
+        logsDir.convention(PropertyTaskConventions.logsDir.getDirectoryValueProvider(project))
         pancakeFlavor.convention(PropertyTaskConventions.pancakeFlavor.getStringValueProvider(project))
         // TODO: Implement getListValueProvider<T>, getListStringValueProvider (common use case),
         //  getValueProvider that takes a serializer
@@ -132,7 +158,9 @@ class PropertyTask extends MockTask {
     }
 
     static class PropertyTaskConventions {
+        static PropertyLookup numbers = new PropertyLookup("FOOBAR_NUMBERS", "foobar.numbers", 7)
         static PropertyLookup bake = new PropertyLookup("FOOBAR_BAKE", "foobar.bake", null)
+        static PropertyLookup logsDir = new PropertyLookup("FOOBAR_LOGS_DIR", "foobar.logsDir", null)
         static PropertyLookup pancakeFlavor = new PropertyLookup("FOOBAR_PANCAKE_FLAVOR", "foobar.pancakeFlavor", null)
         static PropertyLookup tags = new PropertyLookup("FOOBAR_TAGS", "foobar.tags", null)
     }


### PR DESCRIPTION
## Description
Add missing support for:
- Setting test value expectations based on the integration,-
- A few more wildcard overloads
- Missing enum-compatibility methods for PropertyLocation

## Changes
* ![UPDATE] TestValue
* ![UPDATE] PropertyLocation 

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
