### PR TITLE
Add a configuration set invocation

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/PropertyUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/PropertyUtils.groovy
@@ -36,6 +36,13 @@ class PropertyUtils {
     }
 
     /**
+     * @return The components of a property path
+     */
+    static String[] getPathComponents(String path) {
+        path.split(/\./)
+    }
+
+    /**
      * Returns the setter method string for the given property name.
      * <p>
      * If the property name is fully qualified it will split at `.`

--- a/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
@@ -47,8 +47,20 @@ trait TaskIntegrationSpec<T extends DefaultTask> {
         """.stripIndent()
     }
 
+    /**
+     * @deprecated Please use 'addSubjectTask' instead
+     */
+    @Deprecated
     void addMockTask(Boolean force, String... lines) {
+        addSubjectTask(force, lines)
+    }
+
+    void addSubjectTask(Boolean force, String... lines) {
         addTask(subjectUnderTestName, subjectUnderTestTypeName, force, lines)
+    }
+
+    void addSubjectTask() {
+        addSubjectTask(true)
     }
 
     void setSubjectTaskProvider(String name, WrappedValue wrap) {

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertyGetterTaskWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertyGetterTaskWriter.groovy
@@ -107,5 +107,13 @@ class PropertyGetterTaskWriter extends BasePropertyQueryTaskWriter {
             GradleSpecUtils.taskLog(taskName, stdout)
         })
     }
+
+    /**
+     * @return The evaluation to be used for checking the value of the property
+     */
+    PropertyGetterTaskWriter with(PropertyEvaluation evaluation) {
+        this.evaluation = evaluation
+        this
+    }
 }
 

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
@@ -1,5 +1,6 @@
 package com.wooga.gradle.test.writers
 
+import com.oracle.webservices.internal.api.message.PropertySet
 import com.wooga.gradle.test.IntegrationHandler
 import com.wooga.gradle.test.IntegrationSpec
 import com.wooga.gradle.test.PropertyLocation

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertySetInvocationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertySetInvocationSpec.groovy
@@ -12,17 +12,20 @@ class PropertySetInvocationSpec extends Specification {
         expected == actual
 
         where:
-        path          | value | method                                         | expected
-        "foobar"      | "7"   | PropertySetInvocation.providerSet              | "foobar.set(7)"
-        "foobar"      | "7"   | PropertySetInvocation.assignment               | "foobar = 7"
-        "foo.bar"     | "7"   | PropertySetInvocation.assignment               | "foo.bar = 7"
-        "foobar"      | "7"   | PropertySetInvocation.setter                   | "setFoobar(7)"
-        "foo.bar"     | "7"   | PropertySetInvocation.setter                   | "foo.setBar(7)"
-        "foobar"      | "7"   | PropertySetInvocation.method                   | "foobar(7)"
-        "foo.bar"     | "7"   | PropertySetInvocation.method                   | "foo.bar(7)"
-        "foobar"      | "7"   | PropertySetInvocation.customSetter("pancakes") | "pancakes(7)"
-        "foo.bar"     | "7"   | PropertySetInvocation.customSetter("pancakes") | "foo.pancakes(7)"
-        "foo.bar.baz" | "7"   | PropertySetInvocation.customSetter("pancakes") | "foo.bar.pancakes(7)"
+        path          | value | method                                                                   | expected
+        "foobar"      | "7"   | PropertySetInvocation.providerSet                                        | "foobar.set(7)"
+        "foobar"      | "7"   | PropertySetInvocation.assignment                                         | "foobar = 7"
+        "foo.bar"     | "7"   | PropertySetInvocation.assignment                                         | "foo.bar = 7"
+        "foobar"      | "7"   | PropertySetInvocation.setter                                             | "setFoobar(7)"
+        "foo.bar"     | "7"   | PropertySetInvocation.setter                                             | "foo.setBar(7)"
+        "foobar"      | "7"   | PropertySetInvocation.method                                             | "foobar(7)"
+        "foo.bar"     | "7"   | PropertySetInvocation.method                                             | "foo.bar(7)"
+        "foobar"      | "7"   | PropertySetInvocation.customSetter("pancakes")                           | "pancakes(7)"
+        "foo.bar"     | "7"   | PropertySetInvocation.customSetter("pancakes")                           | "foo.pancakes(7)"
+        "foo.bar.baz" | "7"   | PropertySetInvocation.customSetter("pancakes")                           | "foo.bar.pancakes(7)"
+        "foo.bar"     | "7"   | new ConfigurationPropertySetInvocation(PropertySetInvocation.assignment) | "foo {\nbar = 7\n}"
+        "foo.bar"     | "7"   | PropertySetInvocation.configuration(PropertySetInvocation.assignment)    | "foo {\nbar = 7\n}"
+        "foo.bar"     | "7"   | PropertySetInvocation.assignment.inConfiguration()                       | "foo {\nbar = 7\n}"
     }
 
 }

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
@@ -230,5 +230,27 @@ class PropertySetterWriterSpec extends MockTaskIntegrationSpec<PropertyTask> {
             .set(value, type)
         getter = new PropertyGetterTaskWriter(setter)
     }
+
+    @Unroll
+    def "can set property #path with method #method"() {
+        expect:
+        def query = runPropertyQuery(getter, setter)
+        query.matches(value)
+
+        where:
+        property          | nestedProperty | value      | type    | method
+        "consoleSettings" | "useFoobar"    | true       | Boolean | PropertySetInvocation.assignment
+        "consoleSettings" | "useFoobar"    | true       | Boolean | PropertySetInvocation.assignment.inConfiguration()
+        "consoleSettings" | "prefix"       | "pancakes" | String  | PropertySetInvocation.assignment
+        "consoleSettings" | "prefix"       | "waffles"  | String  | PropertySetInvocation.assignment.inConfiguration()
+        "consoleSettings" | "prefix"       | "pancakes" | String  | PropertySetInvocation.customSetter("setMyPrefix")
+        "consoleSettings" | "prefix"       | "waffles"  | String  | PropertySetInvocation.customSetter("setMyPrefix").inConfiguration()
+
+        path = "${property}.get().${nestedProperty}"
+        setter = new PropertySetterWriter(subjectUnderTestName, path)
+            .set(value, type)
+            .use(method)
+        getter = new PropertyGetterTaskWriter(setter, "")
+    }
 }
 

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
@@ -3,16 +3,20 @@ package com.wooga.gradle.test.writers
 import com.wooga.gradle.BaseSpec
 import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.test.mock.MockTask
+import org.gradle.api.Action
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
+
+import static org.gradle.util.ConfigureUtil.configureUsing
 
 class PropertyTask extends MockTask implements BaseSpec {
 
@@ -136,6 +140,31 @@ class PropertyTask extends MockTask implements BaseSpec {
         logsDir.set(value)
     }
 
+    private final Property<ConsoleSettings> consoleSettings = objects.property(ConsoleSettings)
+
+    @Console
+    Property<ConsoleSettings> getConsoleSettings() {
+        consoleSettings
+    }
+
+    void setConsoleSettings(ConsoleSettings value) {
+        consoleSettings.set(value)
+    }
+
+    void setConsoleSettings(Provider<ConsoleSettings> value) {
+        consoleSettings.set(value)
+    }
+
+    void consoleSettings(Closure configuration) {
+        consoleSettings(configureUsing(configuration))
+    }
+
+    void consoleSettings(Action<ConsoleSettings> action) {
+        def settings = consoleSettings.getOrElse(new ConsoleSettings())
+        action.execute(settings)
+        consoleSettings.set(settings)
+    }
+
     PropertyTask() {
         bake = project.objects.property(Boolean)
         logFile = project.objects.fileProperty()
@@ -146,6 +175,7 @@ class PropertyTask extends MockTask implements BaseSpec {
         customEnum = project.objects.property(MockEnum)
         exclude = project.objects.listProperty(File)
 
+        consoleSettings.convention(new ConsoleSettings())
         numbers.convention(PropertyTaskConventions.numbers.getIntegerValueProvider(project))
         bake.convention(PropertyTaskConventions.bake.getBooleanValueProvider(project))
         logsDir.convention(PropertyTaskConventions.logsDir.getDirectoryValueProvider(project))
@@ -182,5 +212,13 @@ class MockObject {
     @Override
     String toString() {
         return name
+    }
+}
+
+class ConsoleSettings {
+    Boolean useFoobar
+    String prefix
+    String setMyPrefix(String value) {
+        this.prefix = value
     }
 }


### PR DESCRIPTION
## Description

Add a new property set invocation type for setting properties through a configuration block; it works seamlessly with the current invocations, as it meant to be used as a modifier of sorts.

For example, given these tests with the older API:

```java
 @Unroll("can configure console settings with #useConfigureBlockMessage #invocation and type #type")
    def "can configure console settings"() {
        given: "a custom xcodebuild task"
        addMockTask(true)

        and: "a task to read back the value"
        buildFile << """
            task("readValue") {
                doLast {
                    println("property: " + ${subjectUnderTestName}.consoleSettings.get().${property})
                }
            }
        """.stripIndent()

        and: "a set property"
        if (useConfigureBlock) {
            buildFile << """
            ${subjectUnderTestName}.consoleSettings {
                ${invocation}
            }
            """.stripIndent()
        } else {
            buildFile << "${subjectUnderTestName}.consoleSettings.get().${invocation}"
        }

        when:
        def result = runTasksSuccessfully("readValue")

        then:
        outputContains(result, "property: " + expectedValue.toString())

        where:
        property      | method           | rawValue                           | type          | useConfigureBlock
        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | false
        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | false
        "colorize"    | _                | "auto"                             | "String"      | false

        "prettyPrint" | "setPrettyPrint" | true                               | "Boolean"     | true
        "prettyPrint" | "setPrettyPrint" | false                              | "Boolean"     | true
        "colorize"    | _                | "always"                           | "String"      | true
        "colorize"    | _                | "never"                            | "String"      | true
        "colorize"    | _                | "auto"                             | "String"      | true

        value = wrapValueBasedOnType(rawValue, type) { type ->
            switch (type) {
                case ConsoleSettings.ColorOption.simpleName:
                    return ConsoleSettings.ColorOption.name + ".${rawValue.toString()}"
                default:
                    return rawValue
            }
        }
        useConfigureBlockMessage = useConfigureBlock ? "configuration closure and" : ""
        invocation = (method == _) ? "${property} = ${value}" : "${method}(${value})"
        expectedValue = rawValue
    }
```

They can now be written in this form:
```java
@Unroll
    def "can set property #path with method #method"() {
        expect:
        def query = runPropertyQuery(getter, setter)
        query.matches(value)

        where:
        property          | nestedProperty | value      | type    | method
        "consoleSettings" | "useFoobar"    | true       | Boolean | PropertySetInvocation.assignment
        "consoleSettings" | "useFoobar"    | true       | Boolean | PropertySetInvocation.assignment.inConfiguration()
        "consoleSettings" | "prefix"       | "pancakes" | String  | PropertySetInvocation.assignment
        "consoleSettings" | "prefix"       | "waffles"  | String  | PropertySetInvocation.assignment.inConfiguration()
        "consoleSettings" | "prefix"       | "pancakes" | String  | PropertySetInvocation.customSetter("setMyPrefix")
        "consoleSettings" | "prefix"       | "waffles"  | String  | PropertySetInvocation.customSetter("setMyPrefix").inConfiguration()

        path = "${property}.get().${nestedProperty}"
        setter = new PropertySetterWriter(subjectUnderTestName, path)
            .set(value, type)
            .use(method)
        getter = new PropertyGetterTaskWriter(setter, "")
    }
```

## Changes
* ![ADD] `ConfigurationPropertySetInvocation`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
