### PR TITLE
Add exit value setter to batchmode wrapper

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/BatchmodeWrapper.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/BatchmodeWrapper.groovy
@@ -9,6 +9,7 @@ class BatchmodeWrapper {
     final String fileName
     Boolean printEnvironment = true
     String text
+    Integer exitValue = 0
 
     BatchmodeWrapper(String fileName) {
         this.fileName = fileName
@@ -34,6 +35,11 @@ class BatchmodeWrapper {
 
     BatchmodeWrapper withText(String text) {
         this.text = text
+        this
+    }
+
+    BatchmodeWrapper withExitValue(Integer value) {
+        this.exitValue = value
         this
     }
 
@@ -84,6 +90,11 @@ class BatchmodeWrapper {
 
         // Custom write
         onWrite(wrapper)
+
+        // Exit code
+        wrapper << """
+        exit ${exitValue}
+        """.stripIndent()
 
         wrapper
     }

--- a/src/test/groovy/com/wooga/gradle/test/BatchmodeWrapperSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/BatchmodeWrapperSpec.groovy
@@ -1,7 +1,6 @@
 package com.wooga.gradle.test
 
 import com.wooga.gradle.ArgumentsSpec
-import com.wooga.gradle.BaseSpec
 import com.wooga.gradle.test.mock.MockTask
 import com.wooga.gradle.test.mock.MockTaskIntegrationSpec
 import org.gradle.api.Action
@@ -48,7 +47,7 @@ class BatchmodeWrapperUsingTask extends MockTask implements ArgumentsSpec {
             }
         })
 
-        execResult.assertNormalExitValue()
+        logger.info("exit value was ${execResult.exitValue}")
     }
 }
 
@@ -103,5 +102,26 @@ class BatchmodeWrapperSpec extends MockTaskIntegrationSpec<BatchmodeWrapperUsing
         fileName | text
         "foobar" | "how now brown cow"
         "foobar" | ""
+    }
+
+    @Unroll
+    def "generates batch wrapper with custom exit value #value"() {
+        given:
+        def wrapper = new BatchmodeWrapper(fileName).withExitValue(value).toTempFile()
+
+        and:
+        appendToSubjectTask("mockExecutable.set(file(${wrapValueBasedOnType(wrapper.absolutePath, String)}))")
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        result.standardOutput.contains("exit value was ${value}")
+
+        where:
+        fileName | value
+        "foobar" | 1
+        "foobar" | 0
+        "foobar" | 2
     }
 }


### PR DESCRIPTION
## Description

Adds an exit value option to the batchmode wrapper.

This can be used like so:

```java
def wrapper = new BatchmodeWrapper(fileName).withExitValue(value)
```

## Changes
* ![UPDATE] `BatchModeWrapper` exit value

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
