### PR TITLE
Add a properties command line flag location

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/PropertyLocation.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/PropertyLocation.groovy
@@ -12,8 +12,14 @@ import static com.wooga.gradle.test.PropertyUtils.envNameFromProperty
  */
 abstract class PropertyLocation {
 
+    /**
+     * @return A description of the location
+     */
     abstract String reason()
-
+    /**
+     * @param args The set of arguments needed by the location to perform the write operation
+     * @return Optionally, a sequence of command line arguments to execute as part of the write operation (by the caller)
+     */
     abstract PropertyWrite write(PropertySetArguments args)
 
     @Override
@@ -21,11 +27,32 @@ abstract class PropertyLocation {
         return reason()
     }
 
+    /**
+     * No location (skipped)
+     */
     static PropertyLocation none = new NonePropertyLocation()
+    /**
+     * To the project's build.gradle script
+     */
     static PropertyLocation script = new BuildScriptPropertyLocation()
+    /**
+     * To the project's gradle.properties file
+     */
     static PropertyLocation property = new PropertiesFilePropertyLocation()
+    /**
+     * To the environment, before invoking the task
+     */
     static PropertyLocation environment = new EnvironmentPropertyLocation()
+    /**
+     * To the command line, as an argument in the task invocation
+     */
     static PropertyLocation commandLine = new CommandLineOptionPropertyLocation()
+
+    /**
+     * To the command line, as an argument in the task invocation using the -P flag.
+     * This location is not considered by default since it has the same function as {@code property}
+     */
+    static PropertyLocation propertyCommandLine = new PropertiesCommandLinePropertyLocation()
 
     static PropertyLocation valueOf(String name) {
         switch (name) {
@@ -102,6 +129,24 @@ class PropertiesFilePropertyLocation extends PropertyLocation {
 }
 
 /**
+ * Sets the property into by through the command line with the -P flag
+ */
+class PropertiesCommandLinePropertyLocation extends PropertyLocation {
+
+    @Override
+    String reason() {
+        "value is provided in properties by -P command line flag"
+    }
+
+    @Override
+    PropertyWrite write(PropertySetArguments args) {
+        def propValue = PropertyUtils.serializeValueToEnvironment(args.value, args.typeName, args.wrapFallback)
+        def commandLineArg = "-P${args.propertyKey ?: args.path}=${propValue}"
+        new PropertyWrite([commandLineArg])
+    }
+}
+
+/**
  * Sets the property onto the system environment
  */
 class EnvironmentPropertyLocation extends PropertyLocation {
@@ -125,9 +170,15 @@ class EnvironmentPropertyLocation extends PropertyLocation {
  */
 class CommandLineOptionPropertyLocation extends PropertyLocation {
 
+    String prefix
     String assignmentOperator
 
     CommandLineOptionPropertyLocation(String assigmentOperator = "=") {
+        this(null, assigmentOperator)
+    }
+
+    CommandLineOptionPropertyLocation(String prefix, String assigmentOperator) {
+        this.prefix = prefix
         this.assignmentOperator = assigmentOperator
     }
 
@@ -142,7 +193,12 @@ class CommandLineOptionPropertyLocation extends PropertyLocation {
             throw new MissingArgumentException("No command line option was provided for '${args.path}'")
         }
 
-        String option = args.commandLineOption
+        String option = ""
+        if (prefix != null) {
+            option += prefix
+        }
+        option += args.commandLineOption
+
         if (args.typeName != "Boolean" && args.value != Wildcard.INSTANCE) {
             def cliValue = PropertyUtils.wrapValueBasedOnType(args.value, args.typeName, args.wrapFallback)
             option += "${assignmentOperator}${cliValue}"

--- a/src/test/groovy/com/wooga/gradle/test/PropertyLocationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/PropertyLocationSpec.groovy
@@ -60,12 +60,12 @@ class PropertyLocationSpec extends Specification {
         expected == actual
 
         where:
-        name          | expected
-        "none"        | PropertyLocation.none
-        "script"      | PropertyLocation.script
-        "property"    | PropertyLocation.property
-        "environment" | PropertyLocation.environment
-        "commandLine" | PropertyLocation.commandLine
+        name                  | expected
+        "none"                | PropertyLocation.none
+        "script"              | PropertyLocation.script
+        "property"            | PropertyLocation.property
+        "environment"         | PropertyLocation.environment
+        "commandLine"         | PropertyLocation.commandLine
     }
 
 }

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertySetterWriterSpec.groovy
@@ -37,6 +37,7 @@ class PropertySetterWriterSpec extends MockTaskIntegrationSpec<PropertyTask> {
         "pancakeFlavor" | "mint"                                                                             | String                  | PropertySetInvocation.providerSet | PropertyLocation.script
         "pancakeFlavor" | "chocolate"                                                                        | String                  | PropertySetInvocation.providerSet | PropertyLocation.environment
         "pancakeFlavor" | "cow"                                                                              | String                  | PropertySetInvocation.providerSet | PropertyLocation.property
+        "pancakeFlavor" | "burger"                                                                           | String                  | PropertySetInvocation.providerSet | PropertyLocation.propertyCommandLine
         "pancakeFlavor" | null                                                                               | String                  | PropertySetInvocation.none        | PropertyLocation.none
         "pancakeFlavor" | null                                                                               | _                       | PropertySetInvocation.none        | PropertyLocation.none
         "pancakeFlavor" | null                                                                               | _                       | _                                 | PropertyLocation.none
@@ -44,11 +45,12 @@ class PropertySetterWriterSpec extends MockTaskIntegrationSpec<PropertyTask> {
         "bake"          | true                                                                               | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.script
         "bake"          | true                                                                               | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.environment
         "bake"          | true                                                                               | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.property
+        "bake"          | true                                                                               | Boolean                 | PropertySetInvocation.assignment  | PropertyLocation.propertyCommandLine
         "tags"          | ["foo", "bar"]                                                                     | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.script
         "tags"          | TestValue.set(["foo", "bar"])                                                      | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.script
         "tags"          | ["foo", "bar"]                                                                     | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.environment
         "tags"          | ["foo", "bar"]                                                                     | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.property
-        "tags"          | ["foo", "bar"]                                                                     | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.property
+        "tags"          | ["foo", "bar"]                                                                     | "List<String>"          | PropertySetInvocation.providerSet | PropertyLocation.propertyCommandLine
         "numbers"       | TestValue.none().expect(PropertyTask.PropertyTaskConventions.numbers.defaultValue) | Integer                 | _                                 | _
 
         setter = new PropertySetterWriter(subjectUnderTestName, property)


### PR DESCRIPTION
## Description
Add an additiional `PropertyLocation`, that of `propertyCommandLine` that can be used to set the property via command line flag -P for gradle properties.

By default, this location is not considered since it has the same function as the existing `property`, which writes to the gradle properties file.

## Changes
* ![ADD] `PropertyLocation.propertyCommandLine`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
