### PR TITLE
Refactor certain SpecUtils methods that were duplicating functionality provided by PlatformUtils

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/SpecUtils.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/SpecUtils.groovy
@@ -1,5 +1,6 @@
 package com.wooga.gradle.test
 
+import com.wooga.gradle.PlatformUtils
 import groovy.json.StringEscapeUtils
 
 import java.nio.file.Files
@@ -23,11 +24,12 @@ class SpecUtils {
         return Files.createTempFile("tmp", "").toFile()
     }
 
+    @Deprecated
+    /**
+     * @deprecated Please use PlatformUtils.escapedPath instead
+     */
     static String escapedPath(String path) {
-        if (isWindows()) {
-            return StringEscapeUtils.escapeJava(path)
-        }
-        return path
+        PlatformUtils.escapedPath(path)
     }
 
     static Throwable rootCause(Throwable e) {
@@ -37,17 +39,26 @@ class SpecUtils {
         return rootCause(e.cause)
     }
 
+    @Deprecated
+    /**
+     * @deprecated Please use the function declared in PlatformUtils instead
+     */
     static boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase().contains("windows")
+        PlatformUtils.windows
     }
 
+    // TODO: Update the check on the PlatforUtils one
     static boolean isUnix() {
-        return System.getProperty("os.name").toLowerCase().contains("linux") ||
+        return PlatformUtils.linux ||
                 System.getProperty("os.name").toLowerCase().contains("unix")
     }
 
+    @Deprecated
+    /**
+     * @deprecated Please use the function declared in PlatformUtils instead
+     */
     static boolean isMacOS() {
-        return System.getProperty("os.name").toLowerCase().contains("mac")
+        PlatformUtils.mac
     }
 
 }


### PR DESCRIPTION
## Description

Several methods in `SpecUtils` are defined already in gradle-commons `PlatformUtils`; it now calls those instead to avoid duplication, and sets deprecation warnings so users can use those instead.

## Changes
* ![UPDATE] SpecUtils

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
