### PR TITLE
Adds functionality to clear environment variables from the given clas…

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/IntegrationSpec.groovy
@@ -17,7 +17,7 @@
 
 package com.wooga.gradle.test
 
-
+import com.wooga.gradle.PropertyLookup
 import com.wooga.gradle.test.queries.PropertyQuery
 import com.wooga.gradle.test.writers.BasePropertyWriter
 import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
@@ -25,6 +25,7 @@ import nebula.test.functional.ExecutionResult
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Shared
 
 import static com.wooga.gradle.PlatformUtils.windows
 
@@ -36,8 +37,15 @@ class IntegrationSpec extends nebula.test.IntegrationSpec implements Integration
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
+    @Shared
+    List<String> declaredEnvironmentVariables = new ArrayList<String>()
+
+    // Called before every feature method
     def setup() {
         environmentVariables.clear()
+        declaredEnvironmentVariables.each {
+            environmentVariables.set(it, null)
+        }
     }
 
     static String osPath(String path) {
@@ -130,9 +138,16 @@ class IntegrationSpec extends nebula.test.IntegrationSpec implements Integration
     PropertyQuery runPropertyQuery(String taskName, PropertyGetterTaskWriter queryTaskWriter, BasePropertyWriter... additional) {
         runPropertyQuery(taskName, queryTaskWriter, additional.toList())
     }
+
+    /**
+     * Clears the environment variables declared by the given class.
+     * @param type A convention class
+     * @return
+     */
+    def clearEnvironmentVariables(Class type) {
+        def values = PropertyLookup.getEnvironmentVariables(type)
+        if (!values.empty) {
+            declaredEnvironmentVariables.addAll(values)
+        }
+    }
 }
-
-
-
-
-

--- a/src/test/groovy/com/wooga/gradle/test/IntegrationSpecIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/IntegrationSpecIntegrationSpec.groovy
@@ -1,0 +1,24 @@
+package com.wooga.gradle.test
+
+import com.wooga.gradle.PropertyLookup
+
+class MockConventionExtension {
+    public static PropertyLookup name = new PropertyLookup("MOCK_FOOBAR", null, "barfoo")
+}
+
+class IntegrationSpecIntegrationSpec extends IntegrationSpec {
+
+    def setupSpec() {
+        clearEnvironmentVariables(MockConventionExtension)
+    }
+
+    def setup() {
+        //environmentVariables.set("MOCK_FOOBAR", "foobar")
+    }
+
+    def "declared environment variables get nulled"() {
+        expect:
+        System.getenv("MOCK_FOOBAR") == null
+    }
+
+}


### PR DESCRIPTION
## Description
Adds helper functions to declare environment to clear before tests start in the integration spec.

## Changes
* ![UPDATE] `IntegrationSpec` Clear environment variables declared by given classes

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
