### PR TITLE
Adds a custom task writer

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
@@ -15,7 +15,9 @@ trait TaskIntegrationSpec<T extends DefaultTask> {
 
     abstract File getBuildFile()
 
-    abstract void addTask(String name, String typeName, Boolean force, String... lines)
+    abstract String addTask(String name, String typeName, Boolean force, String... lines)
+
+    abstract void appendToTask(String taskName, String... lines)
 
     Class<T> getSubjectUnderTestClass() {
         if (!_sutClass) {
@@ -40,11 +42,7 @@ trait TaskIntegrationSpec<T extends DefaultTask> {
     }
 
     void appendToSubjectTask(String... lines) {
-        buildFile << """
-        $subjectUnderTestName {
-            ${lines.join('\n')}
-        }
-        """.stripIndent()
+        appendToTask(subjectUnderTestName, lines)
     }
 
     /**

--- a/src/main/groovy/com/wooga/gradle/test/writers/CustomTaskWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/CustomTaskWriter.groovy
@@ -1,0 +1,106 @@
+package com.wooga.gradle.test.writers
+
+/**
+ * Writes a gradle task onto a build script
+ */
+class CustomTaskWriter {
+
+    /**
+     * The name of the task (as known by the gradle project)
+     */
+    String name
+    /**
+     * The type of the task
+     */
+    String typeName
+    /**
+     * The lines to be written into the task declaration
+     */
+    List<String> lines
+
+    Boolean _force
+    Boolean _register
+
+    CustomTaskWriter(String name, String typeName) {
+        this.name = name
+        this.typeName = typeName
+        this.lines = new ArrayList<String>()
+    }
+
+    CustomTaskWriter(String name, Class type) {
+        this(name, type.name)
+    }
+
+    CustomTaskWriter withLines(Iterable<String> values) {
+        if (values != null) {
+            this.lines.addAll(values)
+        }
+        this
+    }
+
+    CustomTaskWriter withLines(String... values) {
+        if (values != null) {
+            this.lines.addAll(values)
+        }
+        this
+    }
+
+    /**
+     * Forces this task to always run (not get skipped)
+     */
+    CustomTaskWriter force(Boolean value = true) {
+        _force = value
+        this
+    }
+
+    /**
+     * Uses the newer task registration API when creating this task
+     */
+    CustomTaskWriter register(Boolean value = true) {
+        _register = value
+        this
+    }
+
+    /**
+     * Adds a task dependency
+     */
+    CustomTaskWriter dependsOn(String taskName) {
+        withLines("dependsOn ${taskName}")
+    }
+
+    /**
+     * @param buildFile The gradle build script to write to
+     * @return The name of the variable referencing this task
+     */
+    def write(File buildFile) {
+        String variableName = composeVariableName(name)
+        StringBuilder builder = new StringBuilder()
+        String newLine = System.lineSeparator()
+
+        if (_register) {
+            builder.append("""
+def ${variableName} = tasks.register(\"${name}\"${typeName != null ? ", ${typeName}" : ""}) {
+""")
+        } else {
+            builder.append("""
+def ${variableName} = task (${name}, type: ${typeName}) {
+""")
+        }
+
+        if (_force) {
+            builder.append("onlyIf = {true}${newLine}")
+        }
+
+        if (lines.size() > 0) {
+            builder.append("${lines.join(newLine)}${newLine}")
+        }
+
+        builder.append("}${newLine}")
+        buildFile << builder.toString()
+        variableName
+    }
+
+    static String composeVariableName(String taskName) {
+        "${taskName}Task"
+    }
+}

--- a/src/test/groovy/com/wooga/gradle/test/IntegrationSpecIntegrationSpec.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/IntegrationSpecIntegrationSpec.groovy
@@ -1,0 +1,93 @@
+package com.wooga.gradle.test
+
+
+import org.gradle.api.DefaultTask
+import spock.lang.Unroll
+
+class IntegrationSpecIntegrationSpec extends IntegrationSpec {
+
+    @Unroll
+    def "can write task with name #taskName of type #type"() {
+        given:
+        def task = writeTask(taskName, type) {
+            it.force(force)
+                .register(register)
+                .withLines(lines)
+        }
+
+        when:
+        def result = runTasks(taskName)
+
+        then:
+        result.success
+
+        where:
+        taskName | type        | register | force | lines
+        "foobar" | DefaultTask | false    | true  | null
+        "foobar" | DefaultTask | false    | false | null
+        "foobar" | DefaultTask | false    | false | """println("foo")"""
+        "foobar" | DefaultTask | true     | true  | null
+        "foobar" | DefaultTask | true     | false | """println("foo24")"""
+    }
+
+    def "can add task"() {
+        given:
+        def task = addTask(taskName, DefaultTask, true)
+
+        expect:
+        runTasksSuccessfully(taskName)
+        task == "foobarTask"
+
+        where:
+        taskName = "foobar"
+    }
+
+    def "can append to task"() {
+        given:
+        def task = addTask(taskName, DefaultTask, true)
+        appendToTask(taskName, """println("foo")""")
+
+        when:
+        def result = runTasksSuccessfully(taskName)
+
+        then:
+        result.standardOutput.contains("foo")
+
+        where:
+        taskName = "foobar"
+    }
+
+    @Unroll
+    def "can set task dependency directly(#directly)"() {
+        given: "a task A that prints a message"
+        def aTaskName = "A"
+        def a = writeTask(aTaskName, DefaultTask, {
+            it.withLines("""println("${message}")""")
+        })
+
+        and: "a task that depends on A"
+        def bTaskName = "B"
+        def b = writeTask(bTaskName, DefaultTask, {
+            if (directly) {
+                it.dependsOn(a)
+            }
+        })
+        if (!directly) {
+            setTaskDependency(bTaskName, aTaskName)
+        }
+
+        when: "running B will have A executed, printing foo"
+        def result = runTasksSuccessfully(bTaskName)
+
+        then:
+        result.standardOutput.contains(message)
+
+        where:
+        message | directly
+        "foo"   | true
+        "bar"   | false
+
+
+    }
+
+}


### PR DESCRIPTION
## Description
Adds a custom task writer (with a builder API) for writing task add/register onto a build script. This will be used by the `IntegrationSpec`. This will replace the legacy addTask implementation behind the scenes.

It's usage:
```java
def task = writeTask(taskName, type) {
it.force(force)
.register(register)
.withLines(lines)
}
```

## Changes
* ![ADD] `CustomTaskWriter`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
