### PR TITLE
Remove unused result property, expose stdout

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/queries/PropertyQuery.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/queries/PropertyQuery.groovy
@@ -13,12 +13,11 @@ class PropertyQuery {
     //--------------------------------------------------------------------------------------------/
     // Fields
     //--------------------------------------------------------------------------------------------/
-    final ExecutionResult result
     final Boolean success
     final String pattern
     final IntegrationHandler integration
     final PropertyEvaluation evaluation
-    private final String standardOutput
+    final String standardOutput
 
     String typeName
     Boolean enableAssertions = true
@@ -31,7 +30,6 @@ class PropertyQuery {
                   String standardOutput,
                   PropertyEvaluation evaluation,
                   Boolean success = true) {
-        this.result = result
         this.standardOutput = standardOutput
         this.pattern = pattern
         this.integration = integration


### PR DESCRIPTION
## Description
Forgot to remove the unused `result` property, and expose `standardOutput` publicly for use cases where it needs to be accessed.

## Changes
* ![FIX] Remove the unused `result` property, and expose `standardOutput`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
