### PR TITLE
Adds extra preset serializers in PropertyQuery

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/queries/PropertyQuery.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/queries/PropertyQuery.groovy
@@ -4,6 +4,7 @@ import com.wooga.gradle.test.IntegrationHandler
 import com.wooga.gradle.test.writers.PropertyEvaluation
 import nebula.test.functional.ExecutionResult
 import org.apache.commons.io.FileUtils
+import org.gradle.api.file.Directory
 
 /**
  * Used for evaluating the value of a property that was fetched by a script invocation
@@ -178,22 +179,85 @@ class PropertyQuery {
     }
 
     /**
-     * Adds a matcher that will treat all Files as starting from the project root
+     * Adds a serializer that will treat all java.io.File objects being matched as starting from the project root
+     * @return this object
      */
     PropertyQuery withFilePathsRelativeToProject() {
+        withFilePathsRelativeTo("")
+    }
+
+    /**
+     *
+     * Adds a serializer that will treat all java.io.File objects being matched as starting from the project root + dir
+     * @param dir -
+     * @return this object
+     */
+    PropertyQuery withFilePathsRelativeTo(String dir) {
         withSerializer(File, {
-            def relativePath = (String) it
-            new File(integration.projectDir, relativePath).path
+            String relativePath -> pathFromProjectDir(dir, relativePath)
+        })
+    }
+
+
+    /**
+     * Adds a serializer that will treat all Directories being matched as starting from the project root
+     * @return this object
+     */
+    PropertyQuery withDirectoryPathsRelativeToProject() {
+        withDirectoryPathsRelativeTo("")
+    }
+
+    /**
+     *
+     * Adds a serializer that will treat all Directories being matched as starting from the project root + dir
+     * @param dir -
+     * @return this object
+     */
+    PropertyQuery withDirectoryPathsRelativeTo(String dir) {
+        withSerializer(Directory, {
+            String relativePath -> pathFromProjectDir(dir, relativePath)
         })
     }
 
     /**
-     * Adds a matcher that will treat all paths from regular file providers as starting from the project root + dir
+     * Adds a serializer that will treat all RegularFile providers being matched as starting from the project root
+     * @return this object
+     */
+    PropertyQuery withFileProvidersRelativeToProject() {
+        return withFileProvidersRelativeTo("")
+    }
+
+    /**
+     * Adds a serializer that will treat all paths from RegularFile providers being matched as starting from the project root + dir
+     * @param dir
+     * @return this object
      */
     PropertyQuery withFileProvidersRelativeTo(String dir) {
         withSerializer("Provider<RegularFile>", {
-            def relativePath = (String) it
-            FileUtils.getFile(integration.projectDir, dir, relativePath).path
+            String relativePath -> pathFromProjectDir(dir, relativePath)
         })
+    }
+
+    /**
+     * Adds a serializer that will treat all Directory providers being matched as starting from the project root
+     * @return this object
+     */
+    PropertyQuery withDirectoryProvidersRelativeToProject() {
+        return withDirectoryProvidersRelativeTo("")
+    }
+
+    /**
+     * Adds a serializer that will treat all paths from Directory providers being matched as starting from the project root + dir
+     * @param dir
+     * @return this object
+     */
+    PropertyQuery withDirectoryProvidersRelativeTo(String dir) {
+        withSerializer("Provider<Directory>", {
+            String relativePath -> pathFromProjectDir(dir, relativePath)
+        })
+    }
+
+    private String pathFromProjectDir(String dir, String relativePath) {
+        FileUtils.getFile(integration.projectDir, dir, relativePath).path
     }
 }

--- a/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/writers/PropertySetterWriter.groovy
@@ -1,6 +1,5 @@
 package com.wooga.gradle.test.writers
 
-import com.oracle.webservices.internal.api.message.PropertySet
 import com.wooga.gradle.test.IntegrationHandler
 import com.wooga.gradle.test.IntegrationSpec
 import com.wooga.gradle.test.PropertyLocation

--- a/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
+++ b/src/test/groovy/com/wooga/gradle/test/writers/PropertyTask.groovy
@@ -48,6 +48,14 @@ class PropertyTask extends MockTask implements BaseSpec {
         logFile
     }
 
+    private final DirectoryProperty targetDir
+
+    @Optional
+    @InputFile
+    DirectoryProperty getTargetDir() {
+        targetDir
+    }
+
     private final ListProperty<String> tags
 
     ListProperty<String> getTags() {
@@ -168,6 +176,7 @@ class PropertyTask extends MockTask implements BaseSpec {
     PropertyTask() {
         bake = project.objects.property(Boolean)
         logFile = project.objects.fileProperty()
+        targetDir = project.objects.directoryProperty()
         tags = project.objects.listProperty(String)
         pancakeFlavor = project.objects.property(String)
         numbers = project.objects.property(Integer)


### PR DESCRIPTION
##Description
Adds extra preset serializers for dealing with File/RegularFile/Directory objects in PropertyQuery

## Changes
* ![ADD] Adds extra preset serializers in PropertyQuery

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
