### PR TITLE
Add a suffix for the task name for the task integration spec

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/TaskIntegrationSpec.groovy
@@ -34,7 +34,7 @@ trait TaskIntegrationSpec<T extends DefaultTask> {
     private Class<T> _sutClass
 
     String getSubjectUnderTestName() {
-        "${subjectUnderTestClass.simpleName.uncapitalize()}"
+        "${subjectUnderTestClass.simpleName.uncapitalize()}Test"
     }
 
     String getSubjectUnderTestTypeName() {


### PR DESCRIPTION
## Description
Add a suffix to the generated task name for `subjectUnderTest`, due to the task type name being **often** also the task name used by plugins.

## Changes
* ![ADD] `TaskIntegrationSpec` : `subjectUnderTestName` added suffix

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
