### PR TITLE
Fix bug where ArgsReflectorExecutable.Result.allResults was throwing for multiple executions

### DIFF
--- a/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
+++ b/src/main/groovy/com/wooga/gradle/test/executable/ArgsReflectorExecutable.groovy
@@ -127,15 +127,16 @@ class ArgsReflectorExecutable {
      */
     Result[] allResults(String stdOutput) {
         def results = new ArrayList<Result>()
-        def log = stdOutput
-        def currentIndex = log.indexOf(fileTokens[0])
-        while (currentIndex > -1) {
-            def currentLog = log.substring(currentIndex)
+        def currentLog = stdOutput
+        while(true) {
+            def currentIndex = currentLog.indexOf(fileTokens[0])
+            if(currentIndex < 0) {
+                return results
+            }
             results.add(new Result(currentLog))
-            currentIndex = currentLog.substring(currentIndex + fileTokens[0].length()).
-                    indexOf(fileTokens[0])
+            currentLog = currentLog.substring(currentIndex + fileTokens[0].size(), currentLog.size())
+
         }
-        return results
     }
 
 


### PR DESCRIPTION
## Description
`ArgsReflectorExecutable.Result.allResults` wasn't working as expected in its main use case, when there are multiple executions in the same log. This was due to bad implementation and lack of tests (past Joaquim fucked up a little here). 

## Changes
* ![FIX] `ArgsReflectorExecutable.Result.allResults` throwing when more than a single result was present.

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
